### PR TITLE
Add initial draft for AST extractor

### DIFF
--- a/ast/types.ts
+++ b/ast/types.ts
@@ -1,0 +1,26 @@
+export type AST = Array<ClassNode>;
+
+export type Modifiers = Array<string>;
+
+export type ClassNode = {
+  type: "class";
+  modifiers: Modifiers;
+  name: string;
+  body: {
+    methods: Array<MethodNode>;
+  }
+};
+
+export type Param = {
+  typeName: string;
+  argName: string;
+};
+
+export type MethodNode = {
+  type: "method";
+  modifiers: Modifiers;
+  name: string;
+  returnType: string;
+  params: Array<Param>;
+  body: Array<string>;
+};

--- a/astExtractor/ast-extractor.ts
+++ b/astExtractor/ast-extractor.ts
@@ -1,0 +1,33 @@
+import {
+  CstNode,
+  TypeDeclarationCtx,
+} from "java-parser";
+
+import { BaseJavaCstVisitorWithDefaults } from "java-parser";
+import { ClassNode, AST } from "../ast/types";
+import { ClassExtractor } from "./class-extractor";
+
+export class ASTExtractor extends BaseJavaCstVisitorWithDefaults {
+  private ast: Array<ClassNode>;
+
+  constructor() {
+    super();
+    this.ast = [];
+    this.validateVisitor();
+  }
+
+  extract(cst: CstNode): AST {
+    this.ast = [];
+    this.visit(cst);
+    return this.ast;
+  }
+
+  typeDeclaration(ctx: TypeDeclarationCtx, param?: any) {
+    if (ctx.classDeclaration) {
+      ctx.classDeclaration.forEach(x => {
+        const classExtractor = new ClassExtractor();
+        this.ast.push(classExtractor.extract(x));
+      });
+    }
+  }
+}

--- a/astExtractor/class-extractor.ts
+++ b/astExtractor/class-extractor.ts
@@ -1,0 +1,68 @@
+import {
+  ClassMemberDeclarationCtx,
+  ClassModifierCtx,
+  CstNode,
+  TypeIdentifierCtx,
+} from "java-parser";
+
+import { BaseJavaCstVisitorWithDefaults } from "java-parser";
+import { ClassNode, Modifiers, MethodNode } from "../ast/types";
+import { MethodExtractor } from "./method-extractor";
+
+export class ClassExtractor extends BaseJavaCstVisitorWithDefaults {
+  private modifiers: Modifiers;
+  private name: string;
+  private methods: Array<MethodNode>;
+
+  constructor() {
+    super();
+    this.modifiers = [];
+    this.name = '';
+    this.methods = [];
+    this.validateVisitor();
+  }
+
+  extract(cst: CstNode): ClassNode {
+    this.modifiers = [];
+    this.name = '';
+    this.methods = [];
+    this.visit(cst);
+    return {
+      type: 'class',
+      modifiers: this.modifiers,
+      name: this.name,
+      body: {
+        methods: this.methods
+      }
+    };
+  }
+
+  classModifier(ctx: ClassModifierCtx) {
+    const possibleModifiers = [
+      ctx.Public,
+      ctx.Protected,
+      ctx.Private,
+      ctx.Abstract,
+      ctx.Static,
+      ctx.Final,
+      ctx.Sealed,
+      ctx.NonSealed,
+      ctx.Strictfp
+    ].filter(x => x !== undefined).map(x => x ? x[0].image : x);
+    this.modifiers.push(possibleModifiers[0] as string);
+  }
+
+  typeIdentifier(ctx: TypeIdentifierCtx) {
+    this.name = ctx.Identifier[0].image;
+  }
+
+  classMemberDeclaration(ctx: ClassMemberDeclarationCtx) {
+    if (ctx.methodDeclaration) {
+      ctx.methodDeclaration.forEach(x => {
+        const methodExtractor = new MethodExtractor();
+        const methodNode = methodExtractor.extract(x);
+        this.methods.push(methodNode);
+      })
+    }
+  }
+}

--- a/astExtractor/method-extractor.ts
+++ b/astExtractor/method-extractor.ts
@@ -1,0 +1,112 @@
+import {
+  CstNode,
+  DimsCtx,
+  FormalParameterCtx,
+  MethodDeclaratorCtx,
+  MethodModifierCtx,
+  ResultCtx,
+  UnannClassTypeCtx,
+  VariableDeclaratorIdCtx,
+} from "java-parser";
+
+import { BaseJavaCstVisitorWithDefaults } from "java-parser";
+import { Modifiers, MethodNode, Param } from "../ast/types";
+
+export class MethodExtractor extends BaseJavaCstVisitorWithDefaults {
+  private stack: Array<string> = [];
+  private modifiers: Modifiers = [];
+  private returnType: string = '';
+  private name: string = '';
+  private params: Array<Param> = [];
+  private body: Array<string> = [];
+
+  constructor() {
+    super();
+    this.stack = [];
+    this.modifiers = [];
+    this.returnType = '';
+    this.name = '';
+    this.params = [];
+    this.body = [];
+    this.validateVisitor();
+  }
+
+  private getAndPop() {
+    const res = this.stack.at(-1);
+    this.stack.pop();
+    return res as string;
+  }
+
+  extract(cst: CstNode): MethodNode {
+    this.stack = [];
+    this.modifiers = [];
+    this.returnType = '';
+    this.name = '';
+    this.params = [];
+    this.body = [];
+    this.visit(cst);
+    return {
+      type: 'method',
+      modifiers: this.modifiers,
+      returnType: this.returnType,
+      name: this.name,
+      params: this.params,
+      body: this.body
+    };
+  }
+
+  methodModifier(ctx: MethodModifierCtx) {
+    const possibleModifiers = [
+      ctx.Public,
+      ctx.Protected,
+      ctx.Private,
+      ctx.Abstract,
+      ctx.Static,
+      ctx.Final,
+      ctx.Synchronized,
+      ctx.Native,
+      ctx.Strictfp
+    ].filter(x => x !== undefined).map(x => x ? x[0].image : x);
+    this.modifiers.push(possibleModifiers[0] as string);
+  }
+
+  result(ctx: ResultCtx) {
+    if (ctx.Void) {
+      this.returnType = ctx.Void[0].image;
+    }
+  }
+
+  methodDeclarator(ctx: MethodDeclaratorCtx) {
+    this.name = ctx.Identifier[0].image;
+    if (ctx.formalParameterList) {
+      this.visit(ctx.formalParameterList);
+    }
+  }
+
+  formalParameter(ctx: FormalParameterCtx) {
+    if (ctx.variableParaRegularParameter) {
+      this.visit(ctx.variableParaRegularParameter);
+    } else if (ctx.variableArityParameter) {
+      this.visit(ctx.variableArityParameter);
+    }
+
+    const argName = this.getAndPop();
+    const typeName = this.getAndPop();
+    this.params.push({
+      typeName: typeName,
+      argName: argName,
+    });
+  }
+
+  unannClassType(ctx: UnannClassTypeCtx) {
+    this.stack.push(ctx.Identifier[0].image);
+  }
+
+  dims(ctx: DimsCtx) {
+    this.stack[this.stack.length - 1] += "[]";
+  }
+
+  variableDeclaratorId(ctx: VariableDeclaratorIdCtx) {
+    this.stack.push(ctx.Identifier[0].image);
+  }
+}


### PR DESCRIPTION
Current sub-language supported by the AST extractor:
- one or more classes
- each class can have one or more methods
- each method must have `void` return type and `String[]` for argument type
- method body is empty