### PR TITLE
Setup ECE - Evaluate LocalVariableDeclarationStatement

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "java-parser": "^2.0.5"
+    "@types/lodash": "^4.14.198",
+    "java-parser": "^2.0.5",
+    "lodash": "^4.17.21"
   }
 }

--- a/src/ast/astExtractor/ast-extractor.ts
+++ b/src/ast/astExtractor/ast-extractor.ts
@@ -12,12 +12,15 @@ export class ASTExtractor extends BaseJavaCstVisitorWithDefaults {
 
   constructor() {
     super();
-    this.ast = [];
+    this.ast = {
+      type: "CompilationUnit",
+      topLevelClassOrInterfaceDeclarations: []
+    };
     this.validateVisitor();
   }
 
   extract(cst: CstNode): AST {
-    this.ast = [];
+    this.ast.topLevelClassOrInterfaceDeclarations = [];
     this.visit(cst);
     return this.ast;
   }
@@ -26,7 +29,7 @@ export class ASTExtractor extends BaseJavaCstVisitorWithDefaults {
     if (ctx.classDeclaration) {
       ctx.classDeclaration.forEach(x => {
         const classExtractor = new ClassExtractor();
-        this.ast.push(classExtractor.extract(x));
+        this.ast.topLevelClassOrInterfaceDeclarations.push(classExtractor.extract(x));
       });
     }
   }

--- a/src/ast/astExtractor/ast-extractor.ts
+++ b/src/ast/astExtractor/ast-extractor.ts
@@ -13,7 +13,7 @@ export class ASTExtractor extends BaseJavaCstVisitorWithDefaults {
   constructor() {
     super();
     this.ast = {
-      type: "CompilationUnit",
+      kind: "CompilationUnit",
       topLevelClassOrInterfaceDeclarations: []
     };
     this.validateVisitor();

--- a/src/ast/astExtractor/block-statement-extractor.ts
+++ b/src/ast/astExtractor/block-statement-extractor.ts
@@ -36,7 +36,7 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
   extract(cst: BlockStatementCstNode): BlockStatement {
     this.visit(cst);
     return {
-      type: "LocalVariableDeclarationStatement",
+      kind: "LocalVariableDeclarationStatement",
       localVariableType: this.type,
       variableDeclarationList: {
         variableDeclaratorId: this.identifier,
@@ -83,7 +83,7 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
     }
 
     let res = {
-      type: "BinaryExpression",
+      kind: "BinaryExpression",
       operator: processedOperators[0],
       left: processedOperands[0],
       right: processedOperands[1]
@@ -91,7 +91,7 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
 
     for (let i = 1; i < processedOperators.length; i++) {
       res = {
-        type: "BinaryExpression",
+        kind: "BinaryExpression",
         operator: processedOperators[i],
         left: res,
         right: processedOperands[i + 1]
@@ -116,14 +116,14 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
       if (this.isMulOp(operators[i])) {
         if (accMulRes) {
           accMulRes = {
-            type: "BinaryExpression",
+            kind: "BinaryExpression",
               operator: operators[i].image,
               left: accMulRes,
               right: this.visit(operands[i + 1])
           };
         } else {
           accMulRes = {
-            type: "BinaryExpression",
+            kind: "BinaryExpression",
             operator: operators[i].image,
             left: this.visit(operands[i]),
             right: this.visit(operands[i + 1])
@@ -174,7 +174,7 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
   integerLiteral(ctx: IntegerLiteralCtx) {
     if (ctx.DecimalLiteral) {
       return {
-        type: "Literal",
+        kind: "Literal",
         value: Number(ctx.DecimalLiteral[0].image)
       };
     }

--- a/src/ast/astExtractor/block-statement-extractor.ts
+++ b/src/ast/astExtractor/block-statement-extractor.ts
@@ -1,0 +1,124 @@
+import { 
+  BaseJavaCstVisitorWithDefaults, 
+  BinaryExpressionCtx, 
+  BlockStatementCstNode, 
+  ExpressionCtx, 
+  IToken, 
+  IntegerLiteralCtx, 
+  IntegralTypeCtx, 
+  LiteralCtx, 
+  ParenthesisExpressionCtx, 
+  PrimaryCtx, 
+  PrimaryPrefixCtx, 
+  TernaryExpressionCtx, 
+  UnaryExpressionCstNode, 
+  UnaryExpressionCtx, 
+  VariableDeclaratorIdCtx, 
+  VariableInitializerCtx
+} from "java-parser";
+import { 
+  BinaryExpression, 
+  BlockStatement, 
+  Expression, 
+} from "../types/blocks-and-statements";
+import { Identifier, UnannType } from "../types/classes";
+
+export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
+  private type: UnannType;
+  private identifier: Identifier;
+  private value: Expression;
+  
+  constructor() {
+    super();
+    this.validateVisitor();
+  }
+
+  extract(cst: BlockStatementCstNode): BlockStatement {
+    this.visit(cst);
+    return {
+      localVariableType: this.type,
+      variableDeclarationList: {
+        variableDeclaratorId: this.identifier,
+        variableInitializer: this.value
+      }
+    };
+  }
+
+  integralType(ctx: IntegralTypeCtx) {
+    ctx.Int && (this.type = ctx.Int[0].image);
+  }
+
+  variableDeclaratorId(ctx: VariableDeclaratorIdCtx) {
+    this.identifier = ctx.Identifier[0].image
+  }
+
+  variableInitializer(ctx: VariableInitializerCtx) {
+    ctx.expression && (this.value = this.visit(ctx.expression));
+  }
+
+  expression(ctx: ExpressionCtx) {
+    if (ctx.ternaryExpression) {
+      return this.visit(ctx.ternaryExpression);
+    }
+  }
+
+  ternaryExpression(ctx: TernaryExpressionCtx) {
+    return this.visit(ctx.binaryExpression);
+  }
+
+  binaryExpression(ctx: BinaryExpressionCtx) {
+    if (ctx.BinaryOperator && ctx.BinaryOperator.length > 0) {
+      return this.makeBinaryExpression(ctx.BinaryOperator, ctx.unaryExpression);
+    } else {
+      return this.visit(ctx.unaryExpression[0]);
+    }
+  }
+
+  makeBinaryExpression(operators: IToken[], operands: UnaryExpressionCstNode[]): BinaryExpression {
+    if (operators.length == 1 && operands.length == 2) {
+      return {
+        operator: operators[0].image,
+        left: this.visit(operands[0]),
+        right: this.visit(operands[1])
+      }
+    }
+    return {
+      operator: operators[operators.length - 1].image,
+      left: this.makeBinaryExpression(operators.slice(0, -1), operands.slice(0, -1)),
+      right: this.visit(operands[operands.length - 1])
+    }
+  }
+
+  unaryExpression(ctx: UnaryExpressionCtx) {
+    return this.visit(ctx.primary);
+  }
+
+  primary(ctx: PrimaryCtx) {
+    return this.visit(ctx.primaryPrefix);
+  }
+
+  primaryPrefix(ctx: PrimaryPrefixCtx) {
+    if (ctx.literal) {
+      return this.visit(ctx.literal);
+    } else if (ctx.parenthesisExpression) {
+      return this.visit(ctx.parenthesisExpression);
+    }
+  }
+
+  literal(ctx: LiteralCtx) {
+    if (ctx.integerLiteral) {
+      return this.visit(ctx.integerLiteral);
+    }
+  }
+  
+  integerLiteral(ctx: IntegerLiteralCtx) {
+    if (ctx.DecimalLiteral) {
+      return Number(ctx.DecimalLiteral[0].image);
+    }
+    return;
+  }
+  
+  parenthesisExpression(ctx: ParenthesisExpressionCtx) {
+    return this.visit(ctx.expression);
+  }
+}

--- a/src/ast/astExtractor/block-statement-extractor.ts
+++ b/src/ast/astExtractor/block-statement-extractor.ts
@@ -36,6 +36,7 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
   extract(cst: BlockStatementCstNode): BlockStatement {
     this.visit(cst);
     return {
+      type: "LocalVariableDeclarationStatement",
       localVariableType: this.type,
       variableDeclarationList: {
         variableDeclaratorId: this.identifier,
@@ -77,12 +78,14 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
   makeBinaryExpression(operators: IToken[], operands: UnaryExpressionCstNode[]): BinaryExpression {
     if (operators.length == 1 && operands.length == 2) {
       return {
+        type: "BinaryExpression",
         operator: operators[0].image,
         left: this.visit(operands[0]),
         right: this.visit(operands[1])
       }
     }
     return {
+      type: "BinaryExpression",
       operator: operators[operators.length - 1].image,
       left: this.makeBinaryExpression(operators.slice(0, -1), operands.slice(0, -1)),
       right: this.visit(operands[operands.length - 1])
@@ -113,7 +116,10 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
   
   integerLiteral(ctx: IntegerLiteralCtx) {
     if (ctx.DecimalLiteral) {
-      return Number(ctx.DecimalLiteral[0].image);
+      return {
+        type: "Literal",
+        value: Number(ctx.DecimalLiteral[0].image)
+      };
     }
     return;
   }

--- a/src/ast/astExtractor/method-extractor.ts
+++ b/src/ast/astExtractor/method-extractor.ts
@@ -1,4 +1,5 @@
 import {
+  BlockStatementsCtx,
   CstNode,
   DimsCtx,
   FormalParameterCtx,
@@ -9,14 +10,16 @@ import {
 } from "java-parser";
 
 import { BaseJavaCstVisitorWithDefaults } from "java-parser";
-import { MethodModifier, MethodBody, MethodDeclaration, Identifier, FormalParameter } from "../types/classes";
+import { MethodModifier, MethodDeclaration, Identifier, FormalParameter } from "../types/classes";
+import { BlockStatementExtractor } from "./block-statement-extractor";
+import { BlockStatement } from "../types/blocks-and-statements";
 
 export class MethodExtractor extends BaseJavaCstVisitorWithDefaults {
   private stack: Array<string> = [];
   private modifier: Array<MethodModifier>;
   private identifier: Identifier;
   private params: Array<FormalParameter>;
-  private body: MethodBody;
+  private body: Array<BlockStatement>;
 
   constructor() {
     super();
@@ -101,5 +104,12 @@ export class MethodExtractor extends BaseJavaCstVisitorWithDefaults {
 
   variableDeclaratorId(ctx: VariableDeclaratorIdCtx) {
     this.stack.push(ctx.Identifier[0].image);
+  }
+
+  blockStatements(ctx: BlockStatementsCtx) {
+    ctx.blockStatement.forEach(x => {
+      const blockStatementExtractor = new BlockStatementExtractor();
+      this.body.push(blockStatementExtractor.extract(x));
+    })
   }
 }

--- a/src/ast/astExtractor/types.ts
+++ b/src/ast/astExtractor/types.ts
@@ -1,0 +1,22 @@
+import { 
+  BinaryExpression,
+  Literal, 
+  LocalVariableDeclarationStatement 
+} from "../types/blocks-and-statements";
+import { Identifier } from "../types/classes";
+import { CompilationUnit } from "../types/packages-and-modules";
+
+export interface ExpressionMap {
+  BinaryExpression: BinaryExpression;
+  Literal: Literal;
+}
+
+type Expression = ExpressionMap[keyof ExpressionMap]
+
+interface NodeMap {
+  CompilationUnit: CompilationUnit;
+  LocalVariableDeclarationStatement: LocalVariableDeclarationStatement;
+  Expression: Expression;
+}
+
+export type Node = NodeMap[keyof NodeMap];

--- a/src/ast/parser.ts
+++ b/src/ast/parser.ts
@@ -1,0 +1,11 @@
+import { parse as parseToCst } from "java-parser";
+
+import { ASTExtractor } from "./astExtractor/ast-extractor";
+import { AST } from "./types/packages-and-modules";
+
+export const parse = (programStr: string): AST | null => {
+  const cst = parseToCst(programStr);
+  const astExtractor = new ASTExtractor();
+  const ast = astExtractor.extract(cst);
+  return ast;
+}

--- a/src/ast/types/ast.ts
+++ b/src/ast/types/ast.ts
@@ -22,5 +22,5 @@ interface NodeMap {
 export type Node = NodeMap[keyof NodeMap];
 
 export interface BaseNode {
-  type: string;
+  kind: string;
 }

--- a/src/ast/types/ast.ts
+++ b/src/ast/types/ast.ts
@@ -2,9 +2,9 @@ import {
   BinaryExpression,
   Literal, 
   LocalVariableDeclarationStatement 
-} from "../types/blocks-and-statements";
+} from "./blocks-and-statements";
 import { Identifier } from "../types/classes";
-import { CompilationUnit } from "../types/packages-and-modules";
+import { CompilationUnit } from "./packages-and-modules";
 
 export interface ExpressionMap {
   BinaryExpression: BinaryExpression;
@@ -20,3 +20,7 @@ interface NodeMap {
 }
 
 export type Node = NodeMap[keyof NodeMap];
+
+export interface BaseNode {
+  type: string;
+}

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -1,7 +1,8 @@
+import { BaseNode } from "../../ec-evaluator/types";
 import { Identifier, UnannType } from "./classes";
 
 export type BlockStatement = LocalVariableDeclarationStatement;
-export interface LocalVariableDeclarationStatement {
+export interface LocalVariableDeclarationStatement extends BaseNode {
   localVariableType: LocalVariableType;
   variableDeclarationList: VariableDeclarator;
 }
@@ -16,9 +17,11 @@ export type VariableDeclaratorId = Identifier;
 export type VariableInitializer = Expression;
 export type Expression = Literal | BinaryExpression;
 
-export type Literal = number;
+export interface Literal extends BaseNode {
+  value: number
+};
 
-export interface BinaryExpression {
+export interface BinaryExpression extends BaseNode {
   operator: string;
   left: Expression;
   right: Expression;

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -1,0 +1,25 @@
+import { Identifier, UnannType } from "./classes";
+
+export type BlockStatement = LocalVariableDeclarationStatement;
+export interface LocalVariableDeclarationStatement {
+  localVariableType: LocalVariableType;
+  variableDeclarationList: VariableDeclarator;
+}
+
+export type LocalVariableType = UnannType;
+
+export interface VariableDeclarator {
+  variableDeclaratorId: VariableDeclaratorId;
+  variableInitializer: VariableInitializer;
+}
+export type VariableDeclaratorId = Identifier;
+export type VariableInitializer = Expression;
+export type Expression = Literal | BinaryExpression;
+
+export type Literal = number;
+
+export interface BinaryExpression {
+  operator: string;
+  left: Expression;
+  right: Expression;
+}

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from "../../ec-evaluator/types";
+import { BaseNode } from "./ast";
 import { Identifier, UnannType } from "./classes";
 
 export type BlockStatement = LocalVariableDeclarationStatement;

--- a/src/ast/types/classes.ts
+++ b/src/ast/types/classes.ts
@@ -1,3 +1,5 @@
+import { BlockStatement } from "./blocks-and-statements";
+
 export type ClassDeclaration = NormalClassDeclaration;
 
 export interface NormalClassDeclaration {
@@ -23,7 +25,7 @@ export type ClassMemberDeclaration = MethodDeclaration;
 export interface MethodDeclaration {
   methodModifier: Array<MethodModifier>;
   methodHeader: MethodHeader;
-  methodBody: MethodBody;
+  methodBody: Array<BlockStatement>;
 }
 
 export type MethodModifier =

--- a/src/ast/types/packages-and-modules.ts
+++ b/src/ast/types/packages-and-modules.ts
@@ -1,5 +1,8 @@
+import { BaseNode } from "../../ec-evaluator/types";
 import { ClassDeclaration } from "./classes";
 
 export type AST = CompilationUnit;
 export type CompilationUnit = OrdinaryCompilationUnit;
-export type OrdinaryCompilationUnit = Array<ClassDeclaration>;
+export interface OrdinaryCompilationUnit extends BaseNode {
+    topLevelClassOrInterfaceDeclarations: Array<ClassDeclaration>;
+}

--- a/src/ast/types/packages-and-modules.ts
+++ b/src/ast/types/packages-and-modules.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from "../../ec-evaluator/types";
+import { BaseNode } from "./ast";
 import { ClassDeclaration } from "./classes";
 
 export type AST = CompilationUnit;

--- a/src/ec-evaluator/__tests__/ec-evaluator.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator.ts
@@ -126,3 +126,76 @@ it('evaluate multiple local variable declarations correctly', () => {
     expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
   }
 })
+
+it('evaluate local variable declaration to a basic arithmetic expression without brackets to enforce precedence correctly', () => {
+  const programStr = `
+    public class Test {
+      public static void main(String[] args) {
+        int x = 1 + 2 * 3;
+      }
+    }
+    `;
+  const compilationUnit = parse(programStr);
+  if (compilationUnit) {
+    const [result, agendaTrace, stashTrace] = evaluate(compilationUnit);
+
+    const expectedAgendaTrace = [
+      'CompilationUnit',
+      'Pop',
+      'Assignment',
+      'BinaryExpression', // 1 + 2 * 3
+      'BinaryOperation', // +
+      'BinaryExpression',  // 2 * 3
+      'Literal', // 1
+      'BinaryOperation', // *
+      'Literal', // 3
+      'Literal' // 2
+    ];
+    const expectedStashTrace = [1, 2, 3, 6, 7];
+
+    expect(result).toMatchInlineSnapshot(`undefined`);
+    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
+  }
+})
+
+it('evaluate local variable declaration to a complex arithmetic expression without brackets to enforce precedence correctly', () => {
+  const programStr = `
+    public class Test {
+      public static void main(String[] args) {
+        int x = 2 / 1 - 3 * (5 % 4) + 6;
+      }
+    }
+    `;
+  const compilationUnit = parse(programStr);
+  if (compilationUnit) {
+    const [result, agendaTrace, stashTrace] = evaluate(compilationUnit);
+
+    const expectedAgendaTrace = [
+      'CompilationUnit',
+      'Pop',
+      'Assignment',
+      'BinaryExpression', // 2 / 1 - 3 * (5 % 4) + 6
+      'BinaryOperation', // +
+      'Literal', // 6
+      'BinaryExpression', // 2 / 1 - 3 * (5 % 4)
+      'BinaryOperation', // -
+      'BinaryExpression', // 3 * (5 % 4)
+      'BinaryExpression', // 2 / 1
+      'BinaryOperation', // /
+      'Literal', // 1
+      'Literal', // 2
+      'BinaryOperation', // *
+      'BinaryExpression', // (5 % 4)
+      'Literal', // 3
+      'BinaryOperation', // %
+      'Literal', // 4
+      'Literal' // 5
+    ];
+    const expectedStashTrace = [2, 1, 2, 3, 5, 4, 1, 3, -1, 6, 5];
+
+    expect(result).toMatchInlineSnapshot(`undefined`);
+    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
+  }
+})

--- a/src/ec-evaluator/__tests__/ec-evaluator.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator.ts
@@ -1,0 +1,128 @@
+import { evaluate } from "../interpreter";
+import { parse } from "../../ast/parser"
+import { isNode } from "../utils";
+
+it('evaluate local variable declaration to a literal correctly', () => {
+  const programStr = `
+    public class Test {
+      public static void main(String[] args) {
+        int x = 1;
+      }
+    }
+    `;
+  const compilationUnit = parse(programStr);
+  if (compilationUnit) {
+    const [result, agendaTrace, stashTrace] = evaluate(compilationUnit);;
+
+    const expectedAgendaTrace = [
+      'CompilationUnit',
+      'Pop',
+      'Assignment',
+      'Literal'
+    ];
+    const expectedStashTrace = [1];
+
+    expect(result).toMatchInlineSnapshot(`undefined`);
+    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
+  }
+})
+
+it('evaluate local variable declaration to a basic arithmetic operation correctly', () => {
+  const programStr = `
+    public class Test {
+      public static void main(String[] args) {
+        int y = 10 % 2;
+      }
+    }
+    `;
+  const compilationUnit = parse(programStr);
+  if (compilationUnit) {
+    const [result, agendaTrace, stashTrace] = evaluate(compilationUnit);;
+
+    const expectedAgendaTrace = [
+      'CompilationUnit',
+      'Pop',
+      'Assignment',
+      'BinaryExpression', 
+      'BinaryOperation',
+      'Literal',
+      'Literal'
+    ];
+    const expectedStashTrace = [10, 2, 0];
+    
+    expect(result).toMatchInlineSnapshot(`undefined`);
+    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
+  }
+})
+
+it('evaluate local variable declaration to a complex arithmetic operation correctly', () => {
+  const programStr = `
+    public class Test {
+      public static void main(String[] args) {
+        int z = 1 + (2 * 3) - 4;
+      }
+    }
+    `;
+  const compilationUnit = parse(programStr);
+  if (compilationUnit) {
+    const [result, agendaTrace, stashTrace] = evaluate(compilationUnit);;
+
+    const expectedAgendaTrace = [
+      'CompilationUnit',
+      'Pop',
+      'Assignment',
+      'BinaryExpression', 
+      'BinaryOperation',
+      'Literal',
+      'BinaryExpression',
+      'BinaryOperation',
+      'BinaryExpression',
+      'Literal',
+      'BinaryOperation',
+      'Literal',
+      'Literal'
+    ];
+    const expectedStashTrace = [1, 2, 3, 6, 7, 4, 3];
+    
+    expect(result).toMatchInlineSnapshot(`undefined`);
+    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
+  }
+})
+
+it('evaluate multiple local variable declarations correctly', () => {
+  const programStr = `
+    public class Test {
+      public static void main(String[] args) {
+        int x = 1;
+        int y = 10 % 2;
+      }
+    }
+    `;
+  const compilationUnit = parse(programStr);
+  if (compilationUnit) {
+    const [result, agendaTrace, stashTrace] = evaluate(compilationUnit);;
+
+    const expectedAgendaTrace = [
+      'CompilationUnit',
+      'LocalVariableDeclarationStatement',
+      'LocalVariableDeclarationStatement',
+      'Pop',
+      'Assignment',
+      'Literal',
+      'Pop',
+      'Assignment',
+      'BinaryExpression', 
+      'BinaryOperation',
+      'Literal',
+      'Literal'
+    ];
+    const expectedStashTrace = [1, 10, 2, 0];
+
+    expect(result).toMatchInlineSnapshot(`undefined`);
+    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
+  }
+})

--- a/src/ec-evaluator/__tests__/ec-evaluator.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator.ts
@@ -23,7 +23,7 @@ it('evaluate local variable declaration to a literal correctly', () => {
     const expectedStashTrace = [1];
 
     expect(result).toMatchInlineSnapshot(`undefined`);
-    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(agendaTrace.map(i => isNode(i) ? i.kind : i.instrType)).toEqual(expectedAgendaTrace);
     expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
   }
 })
@@ -52,7 +52,7 @@ it('evaluate local variable declaration to a basic arithmetic operation correctl
     const expectedStashTrace = [10, 2, 0];
     
     expect(result).toMatchInlineSnapshot(`undefined`);
-    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(agendaTrace.map(i => isNode(i) ? i.kind : i.instrType)).toEqual(expectedAgendaTrace);
     expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
   }
 })
@@ -87,7 +87,7 @@ it('evaluate local variable declaration to a complex arithmetic operation correc
     const expectedStashTrace = [1, 2, 3, 6, 7, 4, 3];
     
     expect(result).toMatchInlineSnapshot(`undefined`);
-    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(agendaTrace.map(i => isNode(i) ? i.kind : i.instrType)).toEqual(expectedAgendaTrace);
     expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
   }
 })
@@ -122,7 +122,7 @@ it('evaluate multiple local variable declarations correctly', () => {
     const expectedStashTrace = [1, 10, 2, 0];
 
     expect(result).toMatchInlineSnapshot(`undefined`);
-    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(agendaTrace.map(i => isNode(i) ? i.kind : i.instrType)).toEqual(expectedAgendaTrace);
     expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
   }
 })
@@ -154,7 +154,7 @@ it('evaluate local variable declaration to a basic arithmetic expression without
     const expectedStashTrace = [1, 2, 3, 6, 7];
 
     expect(result).toMatchInlineSnapshot(`undefined`);
-    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(agendaTrace.map(i => isNode(i) ? i.kind : i.instrType)).toEqual(expectedAgendaTrace);
     expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
   }
 })
@@ -195,7 +195,7 @@ it('evaluate local variable declaration to a complex arithmetic expression witho
     const expectedStashTrace = [2, 1, 2, 3, 5, 4, 1, 3, -1, 6, 5];
 
     expect(result).toMatchInlineSnapshot(`undefined`);
-    expect(agendaTrace.map(i => isNode(i) ? i.type : i.instrType)).toEqual(expectedAgendaTrace);
+    expect(agendaTrace.map(i => isNode(i) ? i.kind : i.instrType)).toEqual(expectedAgendaTrace);
     expect(stashTrace.map(i => i.value)).toEqual(expectedStashTrace);
   }
 })

--- a/src/ec-evaluator/createContext.ts
+++ b/src/ec-evaluator/createContext.ts
@@ -1,0 +1,72 @@
+import { Context, Environment } from "./types"
+
+export class EnvTree {
+  private _root: EnvTreeNode | null = null
+  private map = new Map<Environment, EnvTreeNode>()
+
+  get root(): EnvTreeNode | null {
+    return this._root
+  }
+
+  public insert(environment: Environment): void {
+    const tailEnvironment = environment.tail
+    if (tailEnvironment === null) {
+      if (this._root === null) {
+        this._root = new EnvTreeNode(environment, null)
+        this.map.set(environment, this._root)
+      }
+    } else {
+      const parentNode = this.map.get(tailEnvironment)
+      if (parentNode) {
+        const childNode = new EnvTreeNode(environment, parentNode)
+        parentNode.addChild(childNode)
+        this.map.set(environment, childNode)
+      }
+    }
+  }
+
+  public getTreeNode(environment: Environment): EnvTreeNode | undefined {
+    return this.map.get(environment)
+  }
+}
+
+export class EnvTreeNode {
+  private _children: EnvTreeNode[] = []
+
+  constructor(readonly environment: Environment, public parent: EnvTreeNode | null) {}
+
+  get children(): EnvTreeNode[] {
+    return this._children
+  }
+
+  public resetChildren(newChildren: EnvTreeNode[]): void {
+    this.clearChildren()
+    this.addChildren(newChildren)
+    newChildren.forEach(c => (c.parent = this))
+  }
+
+  private clearChildren(): void {
+    this._children = []
+  }
+
+  private addChildren(newChildren: EnvTreeNode[]): void {
+    this._children.push(...newChildren)
+  }
+
+  public addChild(newChild: EnvTreeNode): EnvTreeNode {
+    this._children.push(newChild)
+    return newChild
+  }
+}
+
+export const createContext = (): Context => {
+  return {
+    runtime: {
+      environmentTree: new EnvTree(),
+      environments: [],
+      nodes: [],
+      agenda: null,
+      stash: null,
+    },
+  }
+}

--- a/src/ec-evaluator/instrCreator.ts
+++ b/src/ec-evaluator/instrCreator.ts
@@ -1,4 +1,4 @@
-import { Node } from "../ast/astExtractor/types"
+import { Node } from "../ast/types/ast"
 import { AssmtInstr, BinOpInstr, Instr, InstrType } from "./types"
 
 export const assmtInstr = (

--- a/src/ec-evaluator/instrCreator.ts
+++ b/src/ec-evaluator/instrCreator.ts
@@ -1,0 +1,23 @@
+import { Node } from "../ast/astExtractor/types"
+import { AssmtInstr, BinOpInstr, Instr, InstrType } from "./types"
+
+export const assmtInstr = (
+  symbol: string,
+  constant: boolean,
+  declaration: boolean,
+  srcNode: Node
+): AssmtInstr => ({
+  instrType: InstrType.ASSIGNMENT,
+  symbol,
+  constant,
+  declaration,
+  srcNode
+})
+
+export const binOpInstr = (symbol: string, srcNode: Node): BinOpInstr => ({
+  instrType: InstrType.BINARY_OP,
+  symbol,
+  srcNode
+})
+
+export const popInstr = (srcNode: Node): Instr => ({ instrType: InstrType.POP, srcNode })

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -72,7 +72,7 @@ export const evaluate = (compilationUnit: CompilationUnit): [any, AgendaItem[], 
   while (command) {
     agenda.pop()
     if (isNode(command)) {
-      cmdEvaluators[command.type](command, context, agenda, stash)
+      cmdEvaluators[command.kind](command, context, agenda, stash)
     } else {
       // Command is an instrucion
       cmdEvaluators[command.instrType](command, context, agenda, stash)
@@ -107,7 +107,7 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     if (command.topLevelClassOrInterfaceDeclarations[0].classBody[0].methodBody.length == 1) {
       // If program only consists of one statement, evaluate it immediately
       const next = command.topLevelClassOrInterfaceDeclarations[0].classBody[0].methodBody[0]
-      cmdEvaluators[next.type](next, context, agenda, stash)
+      cmdEvaluators[next.kind](next, context, agenda, stash)
       
       // console.log("----------------------------------------------------------------------------")
       // console.log("Agenda: ", agenda);

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -1,0 +1,175 @@
+import { 
+  BinaryExpression, 
+  Literal, 
+  LocalVariableDeclarationStatement, 
+  VariableDeclarator
+} from "../ast/types/blocks-and-statements";
+import { CompilationUnit } from "../ast/types/packages-and-modules";
+import { 
+  Stack, 
+  createBlockEnvironment, 
+  declareVariables, 
+  defineVariable, 
+  evaluateBinaryExpression, 
+  handleSequence, 
+  isNode, 
+  pushEnvironment 
+} from "./utils";
+import { AgendaItem, AssmtInstr, BinOpInstr, Context, Instr, InstrType, Value } from "./types";
+import { Identifier } from "../ast/types/classes";
+import * as instr from './instrCreator'
+import { createContext } from "./createContext";
+
+type CmdEvaluator = (
+  command: AgendaItem,
+  context: Context,
+  agenda: Agenda,
+  stash: Stash,
+) => void
+
+/**
+ * The agenda is a list of commands that still needs to be executed by the machine.
+ * It contains syntax tree nodes or instructions.
+ */
+export class Agenda extends Stack<AgendaItem> {
+  public constructor(compilationUnit: CompilationUnit) {
+    super();
+
+    // Load compilationUnit into agenda stack
+    this.push(compilationUnit);
+  }
+}
+
+/**
+ * The stash is a list of values that stores intermediate results.
+ */
+export class Stash extends Stack<Value> {
+  public constructor() {
+    super()
+  }
+}
+
+/**
+ * The primary runner/loop of the explicit control evaluator.
+ *
+ * @param context The context to evaluate the program in.
+ * @param agenda Points to the current context.runtime.agenda
+ * @param stash Points to the current context.runtime.stash
+ * @returns A special break object if the program is interrupted by a breakpoint;
+ * else the top value of the stash. It is usually the return value of the program.
+ */
+export const evaluate = (compilationUnit: CompilationUnit): [any, AgendaItem[], any[]] => {
+  const context = createContext();
+  const agenda = new Agenda(compilationUnit);
+  const stash = new Stash();
+
+  let command = agenda.peek()
+  
+  // console.log("Agenda: ", agenda);
+  // console.log("Stash: ", stash);
+  // console.log("Environment: ", context.runtime.environments)
+  
+  while (command) {
+    agenda.pop()
+    if (isNode(command)) {
+      cmdEvaluators[command.type](command, context, agenda, stash)
+    } else {
+      // Command is an instrucion
+      cmdEvaluators[command.instrType](command, context, agenda, stash)
+    }
+
+    // console.log("----------------------------------------------------------------------------")
+    // console.log("Agenda: ", agenda);
+    // console.log("Stash: ", stash);
+    // console.log("Environment: ", context.runtime.environments)
+
+    command = agenda.peek()
+  }
+
+  return [stash.peek(), agenda.getTrace(), stash.getTrace()]
+}
+
+/**
+ * Dictionary of functions which handle the logic for the response of the three registers of
+ * the ASE machine to each AgendaItem.
+ */
+const cmdEvaluators: { [type: string]: CmdEvaluator } = {
+  /**
+   * Statements
+   */
+
+  CompilationUnit: (command: CompilationUnit, context:Context, agenda: Agenda, stash: Stash) => {
+    // Create and push the environment only if it is non empty.
+    const environment = createBlockEnvironment(context, 'mainFuncEnvironment')
+    pushEnvironment(context, environment)
+    declareVariables(context, command, environment)
+
+    if (command.topLevelClassOrInterfaceDeclarations[0].classBody[0].methodBody.length == 1) {
+      // If program only consists of one statement, evaluate it immediately
+      const next = command.topLevelClassOrInterfaceDeclarations[0].classBody[0].methodBody[0]
+      cmdEvaluators[next.type](next, context, agenda, stash)
+      
+      // console.log("----------------------------------------------------------------------------")
+      // console.log("Agenda: ", agenda);
+      // console.log("Stash: ", stash);
+      // console.log("Environment: ", context.runtime.environments)
+
+    } else {
+      // Push block body
+      agenda.push(...handleSequence(command.topLevelClassOrInterfaceDeclarations[0].classBody[0].methodBody))
+    }
+  },
+
+  LocalVariableDeclarationStatement: function (
+    command: LocalVariableDeclarationStatement,
+    context:Context,
+    agenda: Agenda,
+    stash: Stash,
+  ) {
+    const declaration: VariableDeclarator = command.variableDeclarationList
+    const id = declaration.variableDeclaratorId as Identifier
+    const init = declaration.variableInitializer
+
+    agenda.push(instr.popInstr(command))
+    agenda.push(instr.assmtInstr(id, false, true, command))
+    agenda.push(init)
+  },
+
+  Literal: (command: Literal, context:Context, agenda: Agenda, stash: Stash) => {
+    stash.push(command);
+  },
+
+  BinaryExpression: function (command: BinaryExpression, context: Context, agenda: Agenda, stash: Stash) {
+    agenda.push(instr.binOpInstr(command.operator, command))
+    agenda.push(command.right)
+    agenda.push(command.left)
+  },
+
+  /**
+   * Instructions
+   */
+  [InstrType.POP]: function (command: Instr, context: Context, agenda: Agenda, stash: Stash) {
+    stash.pop()
+  },
+  
+  [InstrType.ASSIGNMENT]: function (
+    command: AssmtInstr,
+    context: Context,
+    agenda: Agenda,
+    stash: Stash
+  ) {
+    defineVariable(context, command.symbol, stash.peek(), command.constant, 
+      command.srcNode as LocalVariableDeclarationStatement)
+  },
+
+  [InstrType.BINARY_OP]: function (
+    command: BinOpInstr,
+    context: Context,
+    agenda: Agenda,
+    stash: Stash
+  ) {
+    const right = stash.pop()
+    const left = stash.pop()
+    stash.push(evaluateBinaryExpression(command.symbol, left, right))
+  }
+}

--- a/src/ec-evaluator/types.ts
+++ b/src/ec-evaluator/types.ts
@@ -1,0 +1,59 @@
+import { Node } from "../ast/astExtractor/types";
+import { EnvTree } from "./createContext";
+import { Agenda, Stash } from "./interpreter"
+
+export interface Context<T = any> {
+  /** Runtime Specific state */
+  runtime: {
+    environmentTree: EnvTree
+    environments: Environment[]
+    nodes: Node[]
+    agenda: Agenda | null
+    stash: Stash | null
+  }
+}
+
+export interface Environment {
+  id: string
+  name: string
+  tail: Environment | null
+  head: Frame
+}
+
+export interface Frame {
+  [name: string]: any
+}
+
+export enum InstrType {
+  ASSIGNMENT = 'Assignment',
+  BINARY_OP = 'BinaryOperation',
+  POP = 'Pop',
+}
+
+interface BaseInstr {
+  instrType: InstrType
+  srcNode: Node
+}
+
+export interface AssmtInstr extends BaseInstr {
+  symbol: string
+  constant: boolean
+  declaration: boolean
+}
+
+export interface BinOpInstr extends BaseInstr {
+  symbol: string
+}
+
+export type Instr =
+  | BaseInstr
+  | AssmtInstr
+  | BinOpInstr;
+
+export interface BaseNode {
+    type: string;
+}
+
+export type AgendaItem = Node | Instr
+
+export type Value = any

--- a/src/ec-evaluator/types.ts
+++ b/src/ec-evaluator/types.ts
@@ -1,4 +1,4 @@
-import { Node } from "../ast/astExtractor/types";
+import { Node } from "../ast/types/ast";
 import { EnvTree } from "./createContext";
 import { Agenda, Stash } from "./interpreter"
 
@@ -49,10 +49,6 @@ export type Instr =
   | BaseInstr
   | AssmtInstr
   | BinOpInstr;
-
-export interface BaseNode {
-    type: string;
-}
 
 export type AgendaItem = Node | Instr
 

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -1,6 +1,6 @@
 import { uniqueId } from "lodash"
 import { AgendaItem, Context, Environment, Frame, Instr, Value } from "./types"
-import { Node } from "../ast/astExtractor/types"
+import { Node } from "../ast/types/ast"
 import { 
   BlockStatement, 
   Literal, 

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -1,0 +1,202 @@
+import { uniqueId } from "lodash"
+import { AgendaItem, Context, Environment, Frame, Instr, Value } from "./types"
+import { Node } from "../ast/astExtractor/types"
+import { 
+  BlockStatement, 
+  Literal, 
+  LocalVariableDeclarationStatement 
+} from "../ast/types/blocks-and-statements"
+import { CompilationUnit } from "../ast/types/packages-and-modules"
+
+/**
+ * Stack is implemented for agenda and stash registers.
+ */
+interface IStack<T> {
+  push(...items: T[]): void
+  pop(): T | undefined
+  peek(): T | undefined
+  size(): number
+  isEmpty(): boolean
+  getStack(): T[]
+}
+
+export class Stack<T> implements IStack<T> {
+  // Bottom of the array is at index 0
+  private storage: T[] = []
+  private trace: T[] = []
+
+  public constructor() {}
+
+  public push(...items: T[]): void {
+    for (const item of items) {
+      this.storage.push(item);
+      this.trace.push(item);
+    }
+  }
+
+  public pop(): T | undefined {
+    return this.storage.pop()
+  }
+
+  public peek(): T | undefined {
+    if (this.isEmpty()) {
+      return undefined
+    }
+    return this.storage[this.size() - 1]
+  }
+
+  public size(): number {
+    return this.storage.length
+  }
+
+  public isEmpty(): boolean {
+    return this.size() == 0
+  }
+
+  public getStack(): T[] {
+    // return a copy of the stack's contents
+    return [...this.storage]
+  }
+
+  public getTrace(): T[] {
+    return [...this.trace];
+  }
+}
+
+/**
+ * Typeguard for Instr to distinguish between program statements and instructions.
+ *
+ * @param command An AgendaItem
+ * @returns true if the AgendaItem is an instruction and false otherwise.
+ */
+export const isInstr = (command: AgendaItem): command is Instr => {
+  return (command as Instr).instrType !== undefined
+}
+
+/**
+ * Typeguard for esNode to distinguish between program statements and instructions.
+ *
+ * @param command An AgendaItem
+ * @returns true if the AgendaItem is an esNode and false if it is an instruction.
+ */
+export const isNode = (command: AgendaItem): command is Node => {
+  return (command as Node).type !== undefined
+}
+
+/**
+ * A helper function for handling sequences of statements.
+ * Statements must be pushed in reverse order, and each statement is separated by a pop
+ * instruction so that only the result of the last statement remains on stash.
+ * Value producing statements have an extra pop instruction.
+ *
+ * @param seq Array of statements.
+ * @returns Array of commands to be pushed into agenda.
+ */
+export const handleSequence = (seq: BlockStatement[]): AgendaItem[] => {
+  const result: AgendaItem[] = []
+  for (const command of seq) {
+    result.push(command)
+  }
+  // Push statements in reverse order
+  return result.reverse()
+}
+
+/**
+ * Environments
+ */
+
+export const currentEnvironment = (context: Context) => context.runtime.environments[0]
+
+export const createBlockEnvironment = (
+  context: Context,
+  name = 'blockEnvironment',
+  head: Frame = {}
+): Environment => {
+  return {
+    name,
+    tail: currentEnvironment(context),
+    head,
+    id: uniqueId()
+  }
+}
+
+export const pushEnvironment = (context: Context, environment: Environment) => {
+  context.runtime.environments.unshift(environment)
+  context.runtime.environmentTree.insert(environment)
+}
+
+/**
+ * Variables
+ */
+
+const DECLARED_BUT_NOT_YET_ASSIGNED = Symbol('Used to implement block scope')
+
+export function declareVariables(
+  context: Context,
+  node: CompilationUnit,
+  environment: Environment
+) {
+  for (const statement of node.topLevelClassOrInterfaceDeclarations[0].classBody[0].methodBody) {
+    if (statement.type === 'LocalVariableDeclarationStatement') {
+      if (environment.head.hasOwnProperty(statement.variableDeclarationList.variableDeclaratorId)) {
+        throw new Error("Variable re-declared.");
+      }
+      environment.head[statement.variableDeclarationList.variableDeclaratorId] = DECLARED_BUT_NOT_YET_ASSIGNED
+    }
+  }
+  return environment
+}
+
+export function defineVariable(
+  context: Context,
+  name: string,
+  value: Value,
+  constant = false,
+  node: LocalVariableDeclarationStatement
+) {
+  const environment = currentEnvironment(context)
+
+  if (environment.head[name] !== DECLARED_BUT_NOT_YET_ASSIGNED) {
+    throw new Error("Variable not declared.")
+  }
+
+  Object.defineProperty(environment.head, name, {
+    value,
+    writable: !constant,
+    enumerable: true
+  })
+
+  return environment
+}
+
+export const evaluateBinaryExpression = (operator: string, left: Literal, right: Literal) => {
+  switch (operator) {
+    case '+':
+      return {
+        type: "Literal",
+        value: left.value + right.value
+      };
+    case '-':
+      return {
+        type: "Literal",
+        value: left.value - right.value
+      };
+    case '*':
+      return {
+        type: "Literal",
+        value: left.value * right.value
+      };
+    case '/':
+      return {
+        type: "Literal",
+        value: left.value / right.value
+      };
+    case '%':
+      return {
+        type: "Literal",
+        value: left.value % right.value
+      };
+    default:
+      return undefined;
+  }
+}

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -80,7 +80,7 @@ export const isInstr = (command: AgendaItem): command is Instr => {
  * @returns true if the AgendaItem is an esNode and false if it is an instruction.
  */
 export const isNode = (command: AgendaItem): command is Node => {
-  return (command as Node).type !== undefined
+  return (command as Node).kind !== undefined
 }
 
 /**
@@ -137,7 +137,7 @@ export function declareVariables(
   environment: Environment
 ) {
   for (const statement of node.topLevelClassOrInterfaceDeclarations[0].classBody[0].methodBody) {
-    if (statement.type === 'LocalVariableDeclarationStatement') {
+    if (statement.kind === 'LocalVariableDeclarationStatement') {
       if (environment.head.hasOwnProperty(statement.variableDeclarationList.variableDeclaratorId)) {
         throw new Error("Variable re-declared.");
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,6 +637,11 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
+"@types/lodash@^4.14.198":
+  version "4.14.198"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.198.tgz#4d27465257011aedc741a809f1269941fa2c5d4c"
+  integrity sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==
+
 "@types/node@*":
   version "20.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.2.tgz#a065925409f59657022e9063275cd0b9bd7e1b12"
@@ -1908,7 +1913,7 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
-lodash@4.17.21:
+lodash@4.17.21, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Most of the ECE logic is referenced from js-slang.

Due to the limitation of the java-parser library used, expressions such as `1 + 2 * 3` are not parsed with the appropriate precedence of multiplicative operations over additive operations. Hence, some post-processing is done to encode the appropriate precedence. As a result, both types of expression such as `1 + 2 * 3` and  `1 + (2 * 3)` are evaluated correctly.