### PR TITLE
Java parser to generate custom AST

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "java-parser": "^2.0.5"
+    "java-parser": "^2.0.5",
+    "peggy": "^3.0.2"
   }
 }

--- a/src/parser/__tests__/parser.ts
+++ b/src/parser/__tests__/parser.ts
@@ -1,5 +1,4 @@
 import { parse } from "../parser";
-import { expect, describe } from "@jest/globals";
 import * as util from 'util';
 
 function inspect(obj: any) {
@@ -26,7 +25,8 @@ describe('one empty class', () => {
           {
             kind: 'NormalClassDeclaration',
             classModifier: ['public', 'final'],
-            typeIdentifier: 'Java'
+            typeIdentifier: 'Java',
+            classBody: { kind: 'ClassBody', classBodyDeclaration: [] }
           }
         ]
       };
@@ -58,10 +58,174 @@ describe('one empty class', () => {
           {
             kind: 'NormalClassDeclaration',
             classModifier: ['public'],
-            typeIdentifier: 'Test'
+            typeIdentifier: 'Test',
+            classBody: { kind: 'ClassBody', classBodyDeclaration: [] }
           }
         ]
       };
+      expect(result).toEqual(expected);
+    } catch (e) {
+      inspect(e.format([{ text: input }]));
+      fail();
+    }
+  });
+});
+
+describe('one class with methods', () => {
+  test('one method, one argument', () => {
+    const input = `
+      public class Java {
+        public static void Main(String[] args) {
+          // Empty method body
+        }
+      }
+    `;
+
+    try {
+      const result = parse(input);
+      const expected = {
+        kind: 'OrdinaryCompilationUnit',
+        topLevelClassOrInterfaceDeclaration: [
+          {
+            kind: 'NormalClassDeclaration',
+            classModifier: ['public'],
+            typeIdentifier: 'Java',
+            classBody: {
+              kind: 'ClassBody',
+              classBodyDeclaration: [
+                {
+                  kind: 'MethodDeclaration',
+                  methodModifier: ['public', 'static'],
+                  methodHeader: {
+                    kind: 'MethodHeader',
+                    result: 'void',
+                    identifier: 'Main',
+                    formalParameterList: [
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'String[]',
+                        identifier: 'args'
+                      }
+                    ]
+                  },
+                  methodBody: []
+                }
+              ]
+            }
+          }
+        ]
+      };
+      expect(result).toEqual(expected);
+    } catch (e) {
+      inspect(e.format([{ text: input }]));
+      fail();
+    }
+  });
+
+  test('few methods with multiple arguments', () => {
+    const input = `
+      public class JDemo {
+        public static ReturnType Method(int a, String b, boolean c[][]) {
+
+        }
+        private final void PrivateMethod(ObjType[] obj[], char canAlso[]) {
+
+        }
+        public long[] another(float arg1, double arg2) {
+
+        }
+      }
+    `;
+
+    try {
+      const result = parse(input);
+      const expected = {
+        kind: 'OrdinaryCompilationUnit',
+        topLevelClassOrInterfaceDeclaration: [
+          {
+            kind: 'NormalClassDeclaration',
+            classModifier: ['public'],
+            typeIdentifier: 'JDemo',
+            classBody: {
+              kind: 'ClassBody',
+              classBodyDeclaration: [
+                {
+                  kind: 'MethodDeclaration',
+                  methodModifier: ['public', 'static'],
+                  methodHeader: {
+                    kind: 'MethodHeader',
+                    result: 'ReturnType',
+                    identifier: 'Method',
+                    formalParameterList: [
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'int',
+                        identifier: 'a'
+                      },
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'String',
+                        identifier: 'b'
+                      },
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'boolean[][]',
+                        identifier: 'c'
+                      }
+                    ]
+                  },
+                  methodBody: []
+                },
+                {
+                  kind: 'MethodDeclaration',
+                  methodModifier: ['private', 'final'],
+                  methodHeader: {
+                    kind: 'MethodHeader',
+                    result: 'void',
+                    identifier: 'PrivateMethod',
+                    formalParameterList: [
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'ObjType[][]',
+                        identifier: 'obj'
+                      },
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'char[]',
+                        identifier: 'canAlso'
+                      }
+                    ]
+                  },
+                  methodBody: []
+                },
+                {
+                  kind: 'MethodDeclaration',
+                  methodModifier: ['public'],
+                  methodHeader: {
+                    kind: 'MethodHeader',
+                    result: 'long[]',
+                    identifier: 'another',
+                    formalParameterList: [
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'float',
+                        identifier: 'arg1'
+                      },
+                      {
+                        kind: 'FormalParameter',
+                        unannType: 'double',
+                        identifier: 'arg2'
+                      }
+                    ]
+                  },
+                  methodBody: []
+                }
+              ]
+            }
+          }
+        ]
+      }
+        ;
       expect(result).toEqual(expected);
     } catch (e) {
       inspect(e.format([{ text: input }]));

--- a/src/parser/__tests__/parser.ts
+++ b/src/parser/__tests__/parser.ts
@@ -1,13 +1,4 @@
 import { parse } from "../parser";
-import * as util from 'util';
-
-function inspect(obj: any) {
-  console.log(util.inspect(obj, false, null, true));
-}
-
-function fail() {
-  expect(true).toBe(false);
-}
 
 describe('one empty class', () => {
   test('without additional blanks', () => {
@@ -17,24 +8,20 @@ describe('one empty class', () => {
       }
     `;
 
-    try {
-      const result = parse(input);
-      const expected = {
-        kind: 'OrdinaryCompilationUnit',
-        topLevelClassOrInterfaceDeclaration: [
-          {
-            kind: 'NormalClassDeclaration',
-            classModifier: ['public', 'final'],
-            typeIdentifier: 'Java',
-            classBody: { kind: 'ClassBody', classBodyDeclaration: [] }
-          }
-        ]
-      };
-      expect(result).toEqual(expected);
-    } catch (e) {
-      inspect(e.format([{ text: input }]));
-      fail();
-    }
+    const expected = {
+      kind: 'OrdinaryCompilationUnit',
+      topLevelClassOrInterfaceDeclaration: [
+        {
+          kind: 'NormalClassDeclaration',
+          classModifier: ['public', 'final'],
+          typeIdentifier: 'Java',
+          classBody: { kind: 'ClassBody', classBodyDeclaration: [] }
+        }
+      ]
+    };
+
+    const result = parse(input);
+    expect(result).toEqual(expected);
   });
 
   test('with additional blanks and comments', () => {
@@ -50,24 +37,20 @@ describe('one empty class', () => {
       */
     `;
 
-    try {
-      const result = parse(input);
-      const expected = {
-        kind: 'OrdinaryCompilationUnit',
-        topLevelClassOrInterfaceDeclaration: [
-          {
-            kind: 'NormalClassDeclaration',
-            classModifier: ['public'],
-            typeIdentifier: 'Test',
-            classBody: { kind: 'ClassBody', classBodyDeclaration: [] }
-          }
-        ]
-      };
-      expect(result).toEqual(expected);
-    } catch (e) {
-      inspect(e.format([{ text: input }]));
-      fail();
-    }
+    const expected = {
+      kind: 'OrdinaryCompilationUnit',
+      topLevelClassOrInterfaceDeclaration: [
+        {
+          kind: 'NormalClassDeclaration',
+          classModifier: ['public'],
+          typeIdentifier: 'Test',
+          classBody: { kind: 'ClassBody', classBodyDeclaration: [] }
+        }
+      ]
+    };
+
+    const result = parse(input);
+    expect(result).toEqual(expected);
   });
 });
 
@@ -81,45 +64,42 @@ describe('one class with methods', () => {
       }
     `;
 
-    try {
-      const result = parse(input);
-      const expected = {
-        kind: 'OrdinaryCompilationUnit',
-        topLevelClassOrInterfaceDeclaration: [
-          {
-            kind: 'NormalClassDeclaration',
-            classModifier: ['public'],
-            typeIdentifier: 'Java',
-            classBody: {
-              kind: 'ClassBody',
-              classBodyDeclaration: [
-                {
-                  kind: 'MethodDeclaration',
-                  methodModifier: ['public', 'static'],
-                  methodHeader: {
-                    kind: 'MethodHeader',
-                    result: 'void',
-                    identifier: 'Main',
-                    formalParameterList: [
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'String[]',
-                        identifier: 'args'
-                      }
-                    ]
-                  },
-                  methodBody: []
-                }
-              ]
-            }
+    const expected = {
+      kind: 'OrdinaryCompilationUnit',
+      topLevelClassOrInterfaceDeclaration: [
+        {
+          kind: 'NormalClassDeclaration',
+          classModifier: ['public'],
+          typeIdentifier: 'Java',
+          classBody: {
+            kind: 'ClassBody',
+            classBodyDeclaration: [
+              {
+                kind: 'MethodDeclaration',
+                methodModifier: ['public', 'static'],
+                methodHeader: {
+                  kind: 'MethodHeader',
+                  result: 'void',
+                  identifier: 'Main',
+                  formalParameterList: [
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'String[]',
+                      identifier: 'args'
+                    }
+                  ]
+                },
+                methodBody: []
+              }
+            ]
           }
-        ]
-      };
-      expect(result).toEqual(expected);
-    } catch (e) {
-      inspect(e.format([{ text: input }]));
-      fail();
-    }
+        }
+      ]
+    };
+
+    const result = parse(input);
+    expect(result).toEqual(expected);
   });
 
   test('few methods with multiple arguments', () => {
@@ -137,99 +117,288 @@ describe('one class with methods', () => {
       }
     `;
 
-    try {
-      const result = parse(input);
-      const expected = {
-        kind: 'OrdinaryCompilationUnit',
-        topLevelClassOrInterfaceDeclaration: [
-          {
-            kind: 'NormalClassDeclaration',
-            classModifier: ['public'],
-            typeIdentifier: 'JDemo',
-            classBody: {
-              kind: 'ClassBody',
-              classBodyDeclaration: [
-                {
-                  kind: 'MethodDeclaration',
-                  methodModifier: ['public', 'static'],
-                  methodHeader: {
-                    kind: 'MethodHeader',
-                    result: 'ReturnType',
-                    identifier: 'Method',
-                    formalParameterList: [
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'int',
-                        identifier: 'a'
-                      },
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'String',
-                        identifier: 'b'
-                      },
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'boolean[][]',
-                        identifier: 'c'
-                      }
-                    ]
-                  },
-                  methodBody: []
+    const expected = {
+      kind: 'OrdinaryCompilationUnit',
+      topLevelClassOrInterfaceDeclaration: [
+        {
+          kind: 'NormalClassDeclaration',
+          classModifier: ['public'],
+          typeIdentifier: 'JDemo',
+          classBody: {
+            kind: 'ClassBody',
+            classBodyDeclaration: [
+              {
+                kind: 'MethodDeclaration',
+                methodModifier: ['public', 'static'],
+                methodHeader: {
+                  kind: 'MethodHeader',
+                  result: 'ReturnType',
+                  identifier: 'Method',
+                  formalParameterList: [
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'int',
+                      identifier: 'a'
+                    },
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'String',
+                      identifier: 'b'
+                    },
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'boolean[][]',
+                      identifier: 'c'
+                    }
+                  ]
                 },
-                {
-                  kind: 'MethodDeclaration',
-                  methodModifier: ['private', 'final'],
-                  methodHeader: {
-                    kind: 'MethodHeader',
-                    result: 'void',
-                    identifier: 'PrivateMethod',
-                    formalParameterList: [
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'ObjType[][]',
-                        identifier: 'obj'
-                      },
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'char[]',
-                        identifier: 'canAlso'
-                      }
-                    ]
-                  },
-                  methodBody: []
+                methodBody: []
+              },
+              {
+                kind: 'MethodDeclaration',
+                methodModifier: ['private', 'final'],
+                methodHeader: {
+                  kind: 'MethodHeader',
+                  result: 'void',
+                  identifier: 'PrivateMethod',
+                  formalParameterList: [
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'ObjType[][]',
+                      identifier: 'obj'
+                    },
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'char[]',
+                      identifier: 'canAlso'
+                    }
+                  ]
                 },
-                {
-                  kind: 'MethodDeclaration',
-                  methodModifier: ['public'],
-                  methodHeader: {
-                    kind: 'MethodHeader',
-                    result: 'long[]',
-                    identifier: 'another',
-                    formalParameterList: [
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'float',
-                        identifier: 'arg1'
-                      },
-                      {
-                        kind: 'FormalParameter',
-                        unannType: 'double',
-                        identifier: 'arg2'
-                      }
-                    ]
-                  },
-                  methodBody: []
-                }
-              ]
-            }
+                methodBody: []
+              },
+              {
+                kind: 'MethodDeclaration',
+                methodModifier: ['public'],
+                methodHeader: {
+                  kind: 'MethodHeader',
+                  result: 'long[]',
+                  identifier: 'another',
+                  formalParameterList: [
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'float',
+                      identifier: 'arg1'
+                    },
+                    {
+                      kind: 'FormalParameter',
+                      variableModifier: [],
+                      unannType: 'double',
+                      identifier: 'arg2'
+                    }
+                  ]
+                },
+                methodBody: []
+              }
+            ]
           }
-        ]
+        }
+      ]
+    };
+
+    const result = parse(input);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('simple arithmetic expressions', () => {
+  test('addition', () => {
+    const input = `
+      class C {
+        public void f() {
+          int a = 1, b = 2, c = 3, d;
+          c = a + b + c;
+        }
       }
-        ;
-      expect(result).toEqual(expected);
-    } catch (e) {
-      inspect(e.format([{ text: input }]));
-      fail();
+    `;
+
+    const expected = {
+      kind: 'OrdinaryCompilationUnit',
+      topLevelClassOrInterfaceDeclaration: [
+        {
+          kind: 'NormalClassDeclaration',
+          classModifier: [],
+          typeIdentifier: 'C',
+          classBody: {
+            kind: 'ClassBody',
+            classBodyDeclaration: [
+              {
+                kind: 'MethodDeclaration',
+                methodModifier: ['public'],
+                methodHeader: {
+                  kind: 'MethodHeader',
+                  result: 'void',
+                  identifier: 'f',
+                  formalParameterList: []
+                },
+                methodBody: [
+                  {
+                    kind: 'LocalVariableDeclaration',
+                    variableModifier: [],
+                    unannType: 'int',
+                    variableDeclaratorList: [
+                      {
+                        identifier: 'a',
+                        dims: '',
+                        variableInitializer: {
+                          kind: 'ConditionalExpression',
+                          test: { kind: 'Literal', value: '1' }
+                        }
+                      },
+                      {
+                        identifier: 'b',
+                        dims: '',
+                        variableInitializer: {
+                          kind: 'ConditionalExpression',
+                          test: { kind: 'Literal', value: '2' }
+                        }
+                      },
+                      {
+                        identifier: 'c',
+                        dims: '',
+                        variableInitializer: {
+                          kind: 'ConditionalExpression',
+                          test: { kind: 'Literal', value: '3' }
+                        }
+                      },
+                      { identifier: 'd', dims: '' }
+                    ]
+                  },
+                  {
+                    kind: 'AssignmentExpression',
+                    left: 'c',
+                    op: '=',
+                    right: {
+                      kind: 'ConditionalExpression',
+                      test: {
+                        type: 'BinaryExpression',
+                        operator: '+',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '+',
+                          left: { kind: 'NameExpression', name: 'a' },
+                          right: { kind: 'NameExpression', name: 'b' }
+                        },
+                        right: { kind: 'NameExpression', name: 'c' }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    };
+
+    const result = parse(input);
+    expect(result).toEqual(expected);
+  });
+
+  test('addition and multiplication', () => {
+    const input = `
+    class C {
+      public void f() {
+        int a = 1 + 2 * 3 - 4;
+        long b = a << 9;
+      }
     }
+    `;
+
+    const expected = {
+      kind: 'OrdinaryCompilationUnit',
+      topLevelClassOrInterfaceDeclaration: [
+        {
+          kind: 'NormalClassDeclaration',
+          classModifier: [],
+          typeIdentifier: 'C',
+          classBody: {
+            kind: 'ClassBody',
+            classBodyDeclaration: [
+              {
+                kind: 'MethodDeclaration',
+                methodModifier: ['public'],
+                methodHeader: {
+                  kind: 'MethodHeader',
+                  result: 'void',
+                  identifier: 'f',
+                  formalParameterList: []
+                },
+                methodBody: [
+                  {
+                    kind: 'LocalVariableDeclaration',
+                    variableModifier: [],
+                    unannType: 'int',
+                    variableDeclaratorList: [
+                      {
+                        identifier: 'a',
+                        dims: '',
+                        variableInitializer: {
+                          kind: 'ConditionalExpression',
+                          test: {
+                            type: 'BinaryExpression',
+                            operator: '-',
+                            left: {
+                              type: 'BinaryExpression',
+                              operator: '+',
+                              left: { kind: 'Literal', value: '1' },
+                              right: {
+                                type: 'BinaryExpression',
+                                operator: '*',
+                                left: { kind: 'Literal', value: '2' },
+                                right: { kind: 'Literal', value: '3' }
+                              }
+                            },
+                            right: { kind: 'Literal', value: '4' }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    kind: 'LocalVariableDeclaration',
+                    variableModifier: [],
+                    unannType: 'long',
+                    variableDeclaratorList: [
+                      {
+                        identifier: 'b',
+                        dims: '',
+                        variableInitializer: {
+                          kind: 'ConditionalExpression',
+                          test: {
+                            type: 'BinaryExpression',
+                            operator: '<<',
+                            left: { kind: 'NameExpression', name: 'a' },
+                            right: { kind: 'Literal', value: '9' }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    };
+
+    const result = parse(input);
+    expect(result).toEqual(expected);
   });
 });

--- a/src/parser/__tests__/parser.ts
+++ b/src/parser/__tests__/parser.ts
@@ -1,0 +1,71 @@
+import { parse } from "../parser";
+import { expect, describe } from "@jest/globals";
+import * as util from 'util';
+
+function inspect(obj: any) {
+  console.log(util.inspect(obj, false, null, true));
+}
+
+function fail() {
+  expect(true).toBe(false);
+}
+
+describe('one empty class', () => {
+  test('without additional blanks', () => {
+    const input = `
+      public final class Java {
+        // nothing here
+      }
+    `;
+
+    try {
+      const result = parse(input);
+      const expected = {
+        kind: 'OrdinaryCompilationUnit',
+        topLevelClassOrInterfaceDeclaration: [
+          {
+            kind: 'NormalClassDeclaration',
+            classModifier: ['public', 'final'],
+            typeIdentifier: 'Java'
+          }
+        ]
+      };
+      expect(result).toEqual(expected);
+    } catch (e) {
+      inspect(e.format([{ text: input }]));
+      fail();
+    }
+  });
+
+  test('with additional blanks and comments', () => {
+    const input = `
+      /* 
+        Usesless commments
+      */
+      public class Test {
+        // nothing here
+      }
+      /*
+        here and there...
+      */
+    `;
+
+    try {
+      const result = parse(input);
+      const expected = {
+        kind: 'OrdinaryCompilationUnit',
+        topLevelClassOrInterfaceDeclaration: [
+          {
+            kind: 'NormalClassDeclaration',
+            classModifier: ['public'],
+            typeIdentifier: 'Test'
+          }
+        ]
+      };
+      expect(result).toEqual(expected);
+    } catch (e) {
+      inspect(e.format([{ text: input }]));
+      fail();
+    }
+  });
+});

--- a/src/parser/grammar.ts
+++ b/src/parser/grammar.ts
@@ -1,0 +1,516 @@
+export const javaPegGrammar = `
+
+/*
+  Productions from §3 (Lexical Structure)
+*/
+LineTerminator
+  = "\\r\\n"
+  / [\\r\\n] 
+
+Whitespace
+  = [ \\t\\f]
+  / LineTerminator
+
+Comment
+  = "/*" (!"*/" .)* "*/"
+  / "//" (!LineTerminator .)* LineTerminator
+
+// We for now restrict identifier to have only alphanumeric characters.
+Identifier
+  = !Keyword !BooleanLiteral !NullLiteral @$(Letter LetterOrDigit*) _
+
+Letter = [a-zA-Z]
+
+LetterOrDigit = [a-zA-Z0-9]
+
+TypeIdentifier
+  = !permits !record !sealed !var !yield @Identifier
+
+UnqualifiedMethodIdentifier
+  = !yield @Identifier
+
+Literal
+  = FloatingPointLiteral
+  / IntegerLiteral
+  / BooleanLiteral
+  / CharacterLiteral
+  / TextBlock
+  / StringLiteral
+  / NullLiteral
+
+IntegerLiteral
+  = (HexNumeral / BinaryNumeral / OctalNumeral / DecimalNumeral) [lL]?
+
+HexNumeral = ('0x' / '0X') HexDigits
+
+BinaryNumeral = ('0b' / '0B') [01] ([_]* [01])*
+
+OctalNumeral = '0' ([_]* [0-7])+
+
+DecimalNumeral = '0' / [1-9] ([_]* [0-9])*
+
+FloatingPointLiteral = HexadecimalFloatingPointLiteral / DecimalFloatingPointLiteral
+
+DecimalFloatingPointLiteral
+   = Digits '.' Digits?  ExponentPart? [fFdD]?
+    / '.' Digits ExponentPart? [fFdD]?
+    / Digits ExponentPart [fFdD]?
+    / Digits ExponentPart? [fFdD]
+
+ExponentPart = [eE] [+\\-]? Digits
+
+HexadecimalFloatingPointLiteral = HexSignificand BinaryExponentPart [fFdD]?
+
+HexSignificand
+   = ('0x' / '0X') HexDigits? '.' HexDigits
+    / HexNumeral '.'?
+
+BinaryExponentPart = [pP] [+\\-]? Digits
+
+Digits = [0-9] ([_]* [0-9])*
+
+HexDigits = HexDigit ([_]*HexDigit)*
+
+HexDigit = [a-fA-F0-9]
+
+BooleanLiteral
+  = "true"
+  / "false"
+
+CharacterLiteral = ['] (EscapeSequence / !['\\\\] .) [']
+
+StringLiteral = '\\"' (EscapeSequence / !["\\\\\\r\\n] .)* '\\"'
+
+TextBlock
+  = "\\"\\"\\"" ([ \\t\\f])* LineTerminator (EscapeSequence / LineTerminator / ![\\\\\\r\\n] .)* "\\"\\"\\""
+
+EscapeSequence = '\\\\' ([bstnfr"'\\\\] / OctalEscape / UnicodeEscape / LineTerminator)
+
+OctalEscape
+   = [0-3][0-7][0-7]
+    / [0-7][0-7]
+    / [0-7]
+
+UnicodeEscape
+   = 'u'+ HexDigit HexDigit HexDigit HexDigit
+
+NullLiteral
+  = "null"
+
+_ 
+  = (Whitespace / Comment)*
+
+// ReservedKeyword
+abstract = @"abstract" !LetterOrDigit _
+assert = @"assert" !LetterOrDigit _
+boolean = @"boolean" !LetterOrDigit _
+break = @"break" !LetterOrDigit _
+byte = @"byte" !LetterOrDigit _
+case = @"case" !LetterOrDigit _
+catch = @"catch" !LetterOrDigit _
+char = @"char" !LetterOrDigit _
+class = @"class" !LetterOrDigit _
+const = @"const" !LetterOrDigit _
+continue = @"continue" !LetterOrDigit _
+default = @"default" !LetterOrDigit _
+do = @"do" !LetterOrDigit _
+double = @"double" !LetterOrDigit _
+else = @"else" !LetterOrDigit _
+enum = @"enum" !LetterOrDigit _
+extends = @"extends" !LetterOrDigit _
+final = @"final" !LetterOrDigit _
+finally = @"finally" !LetterOrDigit _
+float = @"float" !LetterOrDigit _
+for = @"for" !LetterOrDigit _
+if = @"if" !LetterOrDigit _
+goto = @"goto" !LetterOrDigit _
+implements = @"implements" !LetterOrDigit _
+import = @"import" !LetterOrDigit _
+instanceof = @"instanceof" !LetterOrDigit _
+int = @"int" !LetterOrDigit _
+interface = @"interface" !LetterOrDigit _
+long = @"long" !LetterOrDigit _
+native = @"native" !LetterOrDigit _
+new = @"new" !LetterOrDigit _
+package = @"package" !LetterOrDigit _
+private = @"private" !LetterOrDigit _
+protected = @"protected" !LetterOrDigit _
+public = @"public" !LetterOrDigit _
+return = @"return" !LetterOrDigit _
+short = @"short" !LetterOrDigit _
+static = @"static" !LetterOrDigit _
+strictfp = @"strictfp" !LetterOrDigit _
+super = @"super" !LetterOrDigit _
+switch = @"switch" !LetterOrDigit _
+synchronized = @"synchronized" !LetterOrDigit _
+this = @"this" !LetterOrDigit _
+throw = @"throw" !LetterOrDigit _
+throws = @"throws" !LetterOrDigit _
+transient = @"transient" !LetterOrDigit _
+try = @"try" !LetterOrDigit _
+void = @"void" !LetterOrDigit _
+volatile = @"volatile" !LetterOrDigit _
+while = @"while" !LetterOrDigit _
+underscore = @"_" !LetterOrDigit _
+
+// ContextualKeyword
+exports = @"exports" !LetterOrDigit _
+module = @"module" !LetterOrDigit _
+non_sealed = @"non-sealed" !LetterOrDigit _
+open = @"open" !LetterOrDigit _
+opens = @"opens" !LetterOrDigit _
+permits = @"permits" !LetterOrDigit _
+provides = @"provides" !LetterOrDigit _
+record = @"record" !LetterOrDigit _
+requires = @"requires" !LetterOrDigit _
+sealed = @"sealed" !LetterOrDigit _
+to = @"to" !LetterOrDigit _
+transitive = @"transitive" !LetterOrDigit _
+uses = @"uses" !LetterOrDigit _
+var = @"var" !LetterOrDigit _
+with = @"with" !LetterOrDigit _
+yield = @"yield" !LetterOrDigit _
+
+Keyword
+  = abstract 
+  / assert 
+  / boolean 
+  / break 
+  / byte 
+  / case 
+  / catch 
+  / char 
+  / class 
+  / const 
+  / continue 
+  / default 
+  / do 
+  / double 
+  / else 
+  / enum 
+  / extends 
+  / final 
+  / finally 
+  / float 
+  / for 
+  / if 
+  / goto 
+  / implements 
+  / import 
+  / instanceof 
+  / int 
+  / interface 
+  / long 
+  / native 
+  / new 
+  / package 
+  / private 
+  / protected 
+  / public 
+  / return 
+  / short 
+  / static 
+  / strictfp 
+  / super 
+  / switch 
+  / synchronized 
+  / this 
+  / throw 
+  / throws 
+  / transient 
+  / try 
+  / void 
+  / volatile 
+  / while 
+  / underscore 
+  / exports 
+  / module 
+  / non_sealed
+  / open 
+  / opens 
+  / permits 
+  / provides 
+  / record 
+  / requires 
+  / sealed 
+  / to 
+  / transitive 
+  / uses 
+  / var 
+  / with
+  / yield
+
+// Separators
+lparen = @'(' _
+rparen = @')' _
+lcurly = @'{' _
+rcurly = @'}' _
+lsquare = @'[' _
+rsquare = @']' _
+semicolon = @';' _
+comma = @',' _
+dot = @'.' ![.] _
+ellipsis = @'...' _
+at = @'@' _
+coloncolon = @'::' _
+
+// Operators
+assign = @'=' !'=' _
+equal = @'==' _
+gt = @'>' ![=>] _
+geq = @'>=' _
+lt = @'<' ![=<] _
+leq = @'<=' _
+not = @'!' !'=' _
+noteq = @'!=' _
+andand = @'&&' _
+oror = @'||' _
+tilde = @'~' _
+questionmark = @'?' _
+colon = @':' !':' _
+arrow = @'->' _
+increment = @'++' _
+decrement = @'--' _
+plus = @'+' ![=+] _
+pluseq = @'+=' _
+minus = @'-' ![=\\-] _
+minuseq = @'-=' _
+mul = @'*' !'=' _
+muleq = @'*=' _
+div = @'/' !'=' _
+diveq = @'/=' _
+and = @'&' ![=&] _
+andeq = @'&=' _
+or = @'|' ![=|] _
+oreq = @'|=' _
+xor = @'^' !'=' _
+xoreq = @'^=' _
+mod = @'%' !'=' _
+modeq = @'%=' _
+lshift = @'<<' !'=' _
+lshifteq = @'<<=' _
+rshift = @'>>' ![=>] _
+rshifteq = @'>>=' _
+urshift = @'>>>' !'=' _
+urshifteq = @'>>>=' _
+
+
+
+/*
+  Productions from §4 (Types, Values, and Variables)
+*/
+Type
+  = ReferenceType
+  / PrimitiveType
+
+PrimitiveType
+  = byte
+  / short
+  / int
+  / long
+  / char
+  / float
+  / double
+  / boolean
+
+ReferenceType
+  = (PrimitiveType / ClassType) Dims*
+
+ClassType
+  = ((PackageName dot)? Annotation* TypeIdentifier TypeArguments?)
+    (dot Annotation* TypeIdentifier TypeArguments?)*
+
+Dims
+  = Annotation* lsquare rsquare (Dims)*
+
+TypeArguments
+  = lt TypeArgumentsList gt
+
+TypeArgumentsList
+  = TypeArgument (comma TypeArgument)*
+
+TypeArgument
+  = ReferenceType
+  / Wildcard
+
+Wildcard
+  = Annotation* questionmark ((extends / super) ReferenceType)?
+
+
+
+/*
+  Productions from §6 (Names)
+*/
+ModuleName
+  = Identifier (dot Identifier)*
+
+PackageName
+  = Identifier (dot Identifier)*
+
+TypeName
+  = TypeIdentifier
+  / Identifier dot TypeName
+
+ExpressionName
+  = Identifier (dot Identifier)*
+
+MethodName
+  = UnqualifiedMethodIdentifier
+
+PackageOrTypeName
+  = Identifier (dot Identifier)*
+
+AmbiguousName
+  = Identifier (dot Identifier)*
+
+
+
+/*
+  Productions from §7 (Packages and Modules)
+*/
+CompilationUnit
+  = _ @OrdinaryCompilationUnit
+
+OrdinaryCompilationUnit
+  = PackageDeclaration? ImportDeclaration* tld:TopLevelClassOrInterfaceDeclaration* {
+    return {
+      kind: "OrdinaryCompilationUnit",
+      topLevelClassOrInterfaceDeclaration: tld,
+    }
+  }
+
+PackageDeclaration
+  = TO_BE_ADDED
+
+ImportDeclaration
+  = TO_BE_ADDED
+
+TopLevelClassOrInterfaceDeclaration
+  = ClassDeclaration
+  / InterfaceDeclaration
+  / semicolon
+
+InterfaceDeclaration
+  = TO_BE_ADDED
+
+
+
+/*
+  Productions from §8 (Classes)
+*/
+ClassDeclaration
+  = NormalClassDeclaration
+
+NormalClassDeclaration
+  = cm:ClassModifier* class tm:TypeIdentifier TypeParameters? ClassExtends? ClassImplements? ClassPermits? ClassBody {
+    return {
+      kind: "NormalClassDeclaration",
+      classModifier: cm,
+      typeIdentifier: tm,
+    }
+  }
+
+ClassModifier
+  = public
+  / protected
+  / private
+  / abstract
+  / static
+  / final
+  / sealed
+  / non_sealed
+  / strictfp
+
+TypeParameters
+  = TO_BE_ADDED
+
+TypeParameterList
+  = TO_BE_ADDED
+
+ClassExtends
+  = TO_BE_ADDED
+
+ClassImplements
+  = TO_BE_ADDED
+
+InterfaceTypeList
+  = TO_BE_ADDED
+
+ClassPermits
+  = TO_BE_ADDED
+
+ClassBody
+  = lcurly cbd:ClassBodyDeclaration* rcurly {
+    return {
+      kind: "ClassBody",
+      classBodyDeclaration: cbd,
+    }
+  }
+
+ClassBodyDeclaration
+  = ClassMemberDeclaration
+//  / InstanceInitializer
+//  / StaticInitializer
+//  / ConstructorDeclaration
+
+ClassMemberDeclaration
+  = FieldDeclaration
+  / MethodDeclaration
+  / ClassDeclaration
+  / InterfaceDeclaration
+  / semicolon
+
+FieldDeclaration
+  = FieldModifier* UnannType VariableDeclaratorList semicolon
+
+FieldModifier
+  = public
+  / protected
+  / private
+  / static
+  / final
+  / transient
+  / volatile
+
+VariableDeclaratorList
+  = VariableDeclarator (comma VariableDeclarator)*
+
+VariableDeclarator
+  = VariableDeclaratorId (equal VariableInitializer)?
+
+VariableDeclaratorId
+  = Identifier Dims?
+
+VariableInitializer = TO_BE_ADDED
+
+UnannType
+  = !Annotation @Type
+
+MethodDeclaration
+  = Result Identifier lparen (ReceiverParameter comma)? FormalParameterList? rparen Throws?
+
+Result
+  = UnannType
+  / void
+
+ReceiverParameter
+  = Annotation* UnannType (Identifier dot)? this
+
+FormalParameterList
+  = FormalParameter (comma FormalParameter)*
+
+FormalParameter
+  = VariableModifier* UnannType VariableDeclaratorId
+
+VariableModifier
+  = final
+
+Throws
+  = throw TO_BE_ADDED
+
+// A placeholder that functions as TODO:
+TO_BE_ADDED
+  = ' '
+
+Annotation = at TO_BE_ADDED
+`

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,0 +1,11 @@
+import * as peggy from "peggy";
+import { javaPegGrammar } from "./grammar";
+
+const parser = peggy.generate(javaPegGrammar, {
+  allowedStartRules: ["CompilationUnit"],
+});
+
+export function parse(input: string) {
+  console.log(input);
+  return parser.parse(input);
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -6,6 +6,5 @@ const parser = peggy.generate(javaPegGrammar, {
 });
 
 export function parse(input: string) {
-  console.log(input);
   return parser.parse(input);
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -6,5 +6,6 @@ const parser = peggy.generate(javaPegGrammar, {
 });
 
 export function parse(input: string) {
-  return parser.parse(input);
+  const ast = parser.parse(input);
+  return ast;
 }


### PR DESCRIPTION
### Background
The [java parser library](https://github.com/jhipster/prettier-java/tree/main/packages/java-parser) currently being used returns a concrete syntax tree (CST). The process of converting it into an abstract syntax tree (AST) takes much effort and is complicated by the fact that it does not following Java Language Specification (JLS) faithfully. For example, the precedence of `*` over `+` in the expression `1 + 2 * 3` is not reflected in the CST output.

In an attempt to get rid of above hassles, this PR uses a parser generator [pegjs](https://github.com/peggyjs/peggy/tree/main) to generate a Java parser that can return a custom AST. The references used are as follows:
- [Java grammar](https://docs.oracle.com/javase/specs/jls/se17/html/jls-19.html)
- [pegjs library documentation](https://peggyjs.org/documentation.html)
- [Sample Java PEG grammar](https://github.com/pointlander/peg/blob/master/grammars/java/java_1_7.peg) (it is kind of outdated but useful as a reference
- [Sample PEG grammar from pegjs github](https://github.com/peggyjs/peggy/blob/main/examples/javascript.pegjs)

### Work Done
- [x] Support parsing for simple class and method declaration
- [x] Support parsing for arithmetic expressions
- [ ] Write more tests to check for correctness
