### PR TITLE
Add support for arithmetic expression and if else statement

### DIFF
--- a/src/ClassFile/types/attributes.ts
+++ b/src/ClassFile/types/attributes.ts
@@ -101,7 +101,7 @@ export interface SameFrameExtended {
 export interface AppendFrame {
   frameType: number /* 252-254 */;
   offsetDelta: number;
-  stack: Array<VerificationTypeInfo>;
+  locals: Array<VerificationTypeInfo>;
 }
 
 export interface FullFrame {

--- a/src/ast/astExtractor/ast-extractor.ts
+++ b/src/ast/astExtractor/ast-extractor.ts
@@ -12,7 +12,6 @@ export class ASTExtractor extends BaseJavaCstVisitorWithDefaults {
       kind: "CompilationUnit",
       topLevelClassOrInterfaceDeclarations: [],
     };
-    this.validateVisitor();
   }
 
   extract(cst: CstNode): AST {

--- a/src/ast/astExtractor/block-statement-extractor.ts
+++ b/src/ast/astExtractor/block-statement-extractor.ts
@@ -31,7 +31,6 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
 
   constructor() {
     super();
-    this.validateVisitor();
   }
 
   extract(cst: BlockStatementCstNode): BlockStatement {
@@ -39,10 +38,13 @@ export class BlockStatementExtractor extends BaseJavaCstVisitorWithDefaults {
     return {
       kind: "LocalVariableDeclarationStatement",
       localVariableType: this.type,
-      variableDeclarationList: {
-        variableDeclaratorId: this.identifier,
-        variableInitializer: this.value,
-      },
+      variableDeclaratorList: [
+        {
+          kind: "VariableDeclarator",
+          variableDeclaratorId: this.identifier,
+          variableInitializer: this.value,
+        }
+      ],
     };
   }
 

--- a/src/ast/astExtractor/class-extractor.ts
+++ b/src/ast/astExtractor/class-extractor.ts
@@ -19,7 +19,6 @@ export class ClassExtractor extends BaseJavaCstVisitorWithDefaults {
     this.modifier = [];
     this.identifier = '';
     this.body = [];
-    this.validateVisitor();
   }
 
   extract(cst: CstNode): ClassDeclaration {

--- a/src/ast/astExtractor/method-extractor.ts
+++ b/src/ast/astExtractor/method-extractor.ts
@@ -28,7 +28,6 @@ export class MethodExtractor extends BaseJavaCstVisitorWithDefaults {
     this.identifier = '';
     this.params = [];
     this.body = [];
-    this.validateVisitor();
   }
 
   private getAndPop() {
@@ -48,12 +47,13 @@ export class MethodExtractor extends BaseJavaCstVisitorWithDefaults {
       methodModifier: this.modifier,
       methodHeader: {
         result: "void",
-        methodDeclarator: {
-          identifier: this.identifier,
-          formalParameterList: this.params
-        }
+        identifier: this.identifier,
+        formalParameterList: this.params
       },
-      methodBody: this.body,
+      methodBody: {
+        kind: "Block",
+        blockStatements:this.body,
+      },
     };
   }
 
@@ -89,8 +89,9 @@ export class MethodExtractor extends BaseJavaCstVisitorWithDefaults {
     const argName = this.getAndPop();
     const typeName = this.getAndPop();
     this.params.push({
+      kind: "FormalParameter",
       unannType: typeName,
-      variableDeclaratorId: argName,
+      identifier: argName,
     });
   }
 

--- a/src/ast/types/ast.ts
+++ b/src/ast/types/ast.ts
@@ -3,19 +3,13 @@ import {
   Block,
   BlockStatement,
   Expression,
-  ExpressionName,
-  Literal,
-  LocalVariableDeclarationStatement,
 } from "./blocks-and-statements";
 
 interface NodeMap {
   CompilationUnit: CompilationUnit;
-  LocalVariableDeclarationStatement: LocalVariableDeclarationStatement;
   Block: Block;
   BlockStatement: BlockStatement;
   Expression: Expression;
-  ExpresssionName: ExpressionName;
-  Literal: Literal;
 }
 
 export type Node = NodeMap[keyof NodeMap];

--- a/src/ast/types/ast.ts
+++ b/src/ast/types/ast.ts
@@ -1,28 +1,12 @@
 import { CompilationUnit } from "./packages-and-modules";
 import {
-  Assignment,
-  BinaryExpression,
   Block,
   BlockStatement,
-  BooleanLiteral,
-  CharacterLiteral,
+  Expression,
   ExpressionName,
-  FloatingPointLiteral,
-  IntegerLiteral,
   Literal,
   LocalVariableDeclarationStatement,
-  NullLiteral,
-  StringLiteral,
-  UnaryExpression,
 } from "./blocks-and-statements";
-
-export interface ExpressionMap {
-  BinaryExpression: BinaryExpression;
-  Literal: Literal;
-  UnaryExpression: UnaryExpression;
-}
-
-type Expression = ExpressionMap[keyof ExpressionMap];
 
 interface NodeMap {
   CompilationUnit: CompilationUnit;
@@ -31,13 +15,7 @@ interface NodeMap {
   BlockStatement: BlockStatement;
   Expression: Expression;
   ExpresssionName: ExpressionName;
-  Assignment: Assignment;
-  IntegerLiteral: IntegerLiteral;
-  FloatingPointLiteral: FloatingPointLiteral;
-  BooleanLiteral: BooleanLiteral;
-  CharacterLiteral: CharacterLiteral;
-  StringLiteral: StringLiteral;
-  NullLiteral: NullLiteral;
+  Literal: Literal;
 }
 
 export type Node = NodeMap[keyof NodeMap];

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -12,7 +12,7 @@ export interface LocalVariableDeclarationStatement {
   variableDeclaratorList: Array<VariableDeclarator>;
 }
 
-export type Statement = StatementWithoutTrailingSubstatement | IfStatement | WhileStatement | DoStatement | ForStatement;
+export type Statement = StatementWithoutTrailingSubstatement | IfStatement | WhileStatement | ForStatement;
 
 export interface IfStatement {
   kind: "IfStatement";
@@ -33,13 +33,22 @@ export interface DoStatement {
   body: Statement;
 }
 
-export interface ForStatement {
-  kind: "ForStatement";
+export type ForStatement = BasicForStatement | EnhancedForStatement;
+export interface BasicForStatement {
+  kind: "BasicForStatement";
+  forInit: Array<ExpressionStatement> | LocalVariableDeclarationStatement;
+  condition: Expression;
+  forUpdate: Array<ExpressionStatement>;
+  body: Statement;
 }
 
-export type StatementWithoutTrailingSubstatement = ExpressionStatement;
+export interface EnhancedForStatement {
+  kind: "EnhancedForStatement";
+}
 
-export type ExpressionStatement = MethodInvocation;
+export type StatementWithoutTrailingSubstatement = Block | ExpressionStatement | DoStatement;
+
+export type ExpressionStatement = MethodInvocation | Assignment;
 
 export interface MethodInvocation {
   kind: "MethodInvocation";
@@ -61,7 +70,7 @@ export type VariableDeclaratorId = Identifier;
 export type VariableInitializer = Expression;
 
 export type Expression = Primary | BinaryExpression | UnaryExpression;
-export type Primary = Literal | ExpressionName;
+export type Primary = Literal | ExpressionName | Assignment;
 
 export interface Literal {
   kind: "Literal";

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -10,9 +10,16 @@ export interface LocalVariableDeclarationStatement extends BaseNode {
   variableDeclaratorList: Array<VariableDeclarator>;
 }
 
-export type Statement = StatementWithoutTrailingSubstatement;
+export type Statement = StatementWithoutTrailingSubstatement | IfStatement;
+export interface IfStatement extends BaseNode {
+  test: Expression;
+  consequent: Statement;
+  alternate: Statement;
+}
 export type StatementWithoutTrailingSubstatement = ExpressionStatement;
+
 export type ExpressionStatement = MethodInvocation;
+
 export interface MethodInvocation extends BaseNode {
   identifier: Identifier
   argumentList: ArgumentList;

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -12,13 +12,31 @@ export interface LocalVariableDeclarationStatement {
   variableDeclaratorList: Array<VariableDeclarator>;
 }
 
-export type Statement = StatementWithoutTrailingSubstatement | IfStatement;
+export type Statement = StatementWithoutTrailingSubstatement | IfStatement | WhileStatement | DoStatement | ForStatement;
+
 export interface IfStatement {
   kind: "IfStatement";
-  test: Expression;
+  condition: Expression;
   consequent: Statement;
   alternate: Statement;
 }
+
+export interface WhileStatement {
+  kind: "WhileStatement";
+  condition: Expression;
+  body: Statement;
+}
+
+export interface DoStatement {
+  kind: "DoStatement";
+  condition: Expression;
+  body: Statement;
+}
+
+export interface ForStatement {
+  kind: "ForStatement";
+}
+
 export type StatementWithoutTrailingSubstatement = ExpressionStatement;
 
 export type ExpressionStatement = MethodInvocation;

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -7,7 +7,7 @@ export interface Block extends BaseNode {
 export type BlockStatement = LocalVariableDeclarationStatement | Statement;
 export interface LocalVariableDeclarationStatement extends BaseNode {
   localVariableType: LocalVariableType;
-  variableDeclarationList: VariableDeclarator;
+  variableDeclaratorList: Array<VariableDeclarator>;
 }
 
 export type Statement = StatementWithoutTrailingSubstatement;
@@ -45,3 +45,11 @@ export interface Literal extends BaseNode {
 export interface ExpressionName extends BaseNode {
   name: string;
 }
+
+export interface Assignment extends BaseNode {
+  left: LeftHandSide;
+  operator: string;
+  right: Expression;
+}
+
+export type LeftHandSide = ExpressionName;

--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -1,11 +1,24 @@
 import { BaseNode } from "./ast";
 import { Identifier, UnannType } from "./classes";
 
-export type BlockStatement = LocalVariableDeclarationStatement;
+export interface Block extends BaseNode {
+  blockStatements: Array<BlockStatement>
+}
+export type BlockStatement = LocalVariableDeclarationStatement | Statement;
 export interface LocalVariableDeclarationStatement extends BaseNode {
   localVariableType: LocalVariableType;
   variableDeclarationList: VariableDeclarator;
 }
+
+export type Statement = StatementWithoutTrailingSubstatement;
+export type StatementWithoutTrailingSubstatement = ExpressionStatement;
+export type ExpressionStatement = MethodInvocation;
+export interface MethodInvocation extends BaseNode {
+  identifier: Identifier
+  argumentList: ArgumentList;
+}
+
+export type ArgumentList = Array<Expression>;
 
 export type LocalVariableType = UnannType;
 
@@ -15,14 +28,20 @@ export interface VariableDeclarator {
 }
 export type VariableDeclaratorId = Identifier;
 export type VariableInitializer = Expression;
-export type Expression = Literal | BinaryExpression;
-
-export interface Literal extends BaseNode {
-  value: number
-};
+export type Expression = BinaryExpression | Primary;
 
 export interface BinaryExpression extends BaseNode {
   operator: string;
   left: Expression;
   right: Expression;
+}
+
+export type Primary = Literal | ExpressionName;
+
+export interface Literal extends BaseNode {
+  value: string
+};
+
+export interface ExpressionName extends BaseNode {
+  name: string;
 }

--- a/src/ast/types/classes.ts
+++ b/src/ast/types/classes.ts
@@ -1,4 +1,4 @@
-import { BlockStatement } from "./blocks-and-statements";
+import { Block } from "./blocks-and-statements";
 
 export type ClassDeclaration = NormalClassDeclaration;
 
@@ -41,14 +41,11 @@ export type MethodModifier =
 
 export interface MethodHeader {
   result: Result;
-  methodDeclarator: MethodDeclarator;
-}
-
-export type Result = "void";
-export interface MethodDeclarator {
   identifier: Identifier;
   formalParameterList: Array<FormalParameter>;
 }
+
+export type Result = "void";
 
 export interface FormalParameter {
   unannType: UnannType;
@@ -58,5 +55,5 @@ export interface FormalParameter {
 export type UnannType = string;
 export type VariableDeclaratorId = Identifier;
 
-export type MethodBody = Array<BlockStatement>;
+export type MethodBody = Block;
 export type Identifier = string;

--- a/src/ast/types/classes.ts
+++ b/src/ast/types/classes.ts
@@ -1,3 +1,4 @@
+import { BaseNode } from "./ast";
 import { Block } from "./blocks-and-statements";
 
 export type ClassDeclaration = NormalClassDeclaration;
@@ -47,9 +48,9 @@ export interface MethodHeader {
 
 export type Result = "void";
 
-export interface FormalParameter {
+export interface FormalParameter extends BaseNode {
   unannType: UnannType;
-  variableDeclaratorId: Identifier;
+  identifier: Identifier;
 }
 
 export type UnannType = string;

--- a/src/compiler/binary-writer.ts
+++ b/src/compiler/binary-writer.ts
@@ -22,6 +22,8 @@ import {
 import { FieldInfo } from "../ClassFile/types/fields";
 import { MethodInfo } from "../ClassFile/types/methods";
 
+import * as fs from "fs";
+
 const u1 = 1;
 const u2 = 2;
 const u4 = 4;
@@ -35,7 +37,13 @@ export class BinaryWriter {
     this.constantPool = [];
   }
 
-  toBinary(classFile: ClassFile) {
+  writeBinary(classFile: ClassFile) {
+    const filename = "Main.class";
+    const binary = this.toBinary(classFile);
+    fs.writeFileSync(filename, binary);
+  }
+
+  private toBinary(classFile: ClassFile) {
     this.byteArray = [];
     this.constantPool = classFile.constantPool;
 
@@ -62,7 +70,7 @@ export class BinaryWriter {
 
 
   private write(value: number, numOfBytes: number = u1) {
-    const bytes = [];
+    const bytes: Array<number> = [];
     for (let i = 0; i < numOfBytes; i++) {
       bytes.push(value & 0xff);
       value >>>= 8;

--- a/src/compiler/binary-writer.ts
+++ b/src/compiler/binary-writer.ts
@@ -37,8 +37,8 @@ export class BinaryWriter {
     this.constantPool = [];
   }
 
-  writeBinary(classFile: ClassFile) {
-    const filename = "Main.class";
+  writeBinary(classFile: ClassFile, filepath: string) {
+    const filename = filepath + "Main.class";
     const binary = this.toBinary(classFile);
     fs.writeFileSync(filename, binary);
   }

--- a/src/compiler/code-generator.ts
+++ b/src/compiler/code-generator.ts
@@ -1,0 +1,95 @@
+import { OPCODE } from "../ClassFile/constants/instructions";
+import { ExceptionHandler, AttributeInfo } from "../ClassFile/types/attributes";
+import { BaseNode } from "../ast/types/ast";
+import { MethodInvocation, Literal, Block } from "../ast/types/blocks-and-statements";
+import { MethodDeclaration } from "../ast/types/classes";
+import { ConstantPoolManager } from "./constant-pool-manager";
+import { SymbolTable, SymbolType } from "./symbol-table"
+
+const codeGenerators: { [type: string]: (node: BaseNode, cg: CodeGenerator) => number } = {
+  Block: (node: BaseNode, cg: CodeGenerator) => {
+    const n = node as Block;
+    let maxStack = 0;
+    n.blockStatements.forEach(x => {
+      maxStack = Math.max(maxStack, codeGenerators[x.kind](x, cg));
+    })
+    return maxStack;
+  },
+
+  MethodInvocation: (node: BaseNode, cg: CodeGenerator) => {
+    const n = node as MethodInvocation;
+    let maxStack = 1;
+
+    const { parentClassName: p1, typeDescriptor: t1 } = cg.symbolTable.query("out", SymbolType.CLASS);
+    const { parentClassName: p2, typeDescriptor: t2 } = cg.symbolTable.query("println", SymbolType.CLASS);
+    const out = cg.constantPoolManager.indexFieldrefInfo(p1 as string, "out", t1 as string);
+    const println = cg.constantPoolManager.indexMethodrefInfo(p2 as string, "println", t2 as string);
+
+    cg.code.push(OPCODE.GETSTATIC, 0, out);
+    n.argumentList.forEach((x, i) => {
+      maxStack = Math.max(maxStack, i + 1 + codeGenerators[x.kind](x, cg));
+    })
+    cg.code.push(OPCODE.INVOKEVIRTUAL, 0, println);
+    return maxStack;
+  },
+
+  StringLiteral: (node: BaseNode, cg: CodeGenerator) => {
+    const n = node as Literal;
+    const strIdx = cg.constantPoolManager.indexStringInfo(n.value);
+    cg.code.push(OPCODE.LDC, strIdx);
+    return 1;
+  }
+}
+
+class CodeGenerator {
+  symbolTable: SymbolTable;
+  constantPoolManager: ConstantPoolManager;
+  maxLocals = 0;
+  code: number[] = [];
+
+  constructor(symbolTable: SymbolTable, constantPoolManager: ConstantPoolManager) {
+    this.symbolTable = symbolTable;
+    this.constantPoolManager = constantPoolManager;
+  }
+
+  generateCode(methodNode: MethodDeclaration) {
+    this.symbolTable.extend();
+    methodNode.methodHeader.formalParameterList.forEach(p => {
+      this.symbolTable.insert(p.variableDeclaratorId, SymbolType.VARIABLE, {
+        index: this.maxLocals
+      });
+      this.maxLocals++;
+    });
+
+    const { methodBody } = methodNode;
+    const maxStack = Math.max(this.maxLocals, codeGenerators[methodBody.kind](methodBody, this));
+    const exceptionTable: Array<ExceptionHandler> = [];
+    const attributes: Array<AttributeInfo> = [];
+
+    this.code.push(OPCODE.RETURN);
+    const codeBuf = new Uint8Array(this.code).buffer;
+    const dataView = new DataView(codeBuf);
+    this.code.forEach((x, i) => dataView.setUint8(i, x));
+
+    const attributeLength = 12 + this.code.length + 8 * exceptionTable.length +
+      attributes.map(attr => attr.attributeLength + 6).reduce((acc, val) => acc + val, 0);
+    return {
+      attributeNameIndex: this.constantPoolManager.indexUtf8Info("Code"),
+      attributeLength: attributeLength,
+      maxStack: maxStack,
+      maxLocals: this.maxLocals,
+      codeLength: this.code.length,
+      code: dataView,
+      exceptionTableLength: exceptionTable.length,
+      exceptionTable: exceptionTable,
+      attributesCount: attributes.length,
+      attributes: attributes
+    }
+  }
+}
+
+export function generateCode(symbolTable: SymbolTable, constantPoolManager: ConstantPoolManager,
+  methodNode: MethodDeclaration) {
+  const codeGenerator = new CodeGenerator(symbolTable, constantPoolManager);
+  return codeGenerator.generateCode(methodNode);
+}

--- a/src/compiler/code-generator.ts
+++ b/src/compiler/code-generator.ts
@@ -11,7 +11,7 @@ import {
   Assignment,
   IfStatement,
   StringLiteral,
-  IntegerLiteral
+  DecimalIntegerLiteral
 } from "../ast/types/blocks-and-statements";
 import { MethodDeclaration } from "../ast/types/classes";
 import { ConstantPoolManager } from "./constant-pool-manager";
@@ -200,8 +200,8 @@ const codeGenerators: { [type: string]: (node: Node, cg: CodeGenerator) => numbe
     return 1;
   },
 
-  IntegerLiteral: (node: Node, cg: CodeGenerator) => {
-    const { value: value } = node as IntegerLiteral;
+  DecimalIntegerLiteral: (node: Node, cg: CodeGenerator) => {
+    const { value: value } = node as DecimalIntegerLiteral;
     const n = parseInt(value);
     if (-128 <= n && n < 128) {
       cg.code.push(OPCODE.BIPUSH, n);

--- a/src/compiler/compiler-utils.ts
+++ b/src/compiler/compiler-utils.ts
@@ -1,6 +1,6 @@
 import { ACCESS_FLAGS } from "../ClassFile/types";
 import { METHOD_FLAGS } from "../ClassFile/types/methods";
-import { ClassModifier, FormalParameter, MethodModifier, UnannType } from "../ast/types/classes";
+import { ClassModifier, MethodModifier, UnannType } from "../ast/types/classes";
 
 const typeMap = new Map([
   ['byte', 'B'],
@@ -27,16 +27,12 @@ export function generateFieldDescriptor(typeName: UnannType) {
   typeName = typeName.slice(0, last);
   if (typeName === "String") {
     typeName = "java/lang/String";
-  } else if (typeName === "System") {
-    typeName = "java/lang/System";
-  } else if (typeName === "PrintStream") {
-    typeName = "java/io/PrintStream";
   }
   return "[".repeat(dim) + (typeMap.has(typeName) ? typeMap.get(typeName) : 'L' + typeName + ';');
 }
 
-export function generateMethodDescriptor(params: Array<FormalParameter>, result: string) {
-  const paramsDescriptor = params.map(p => generateFieldDescriptor(p.unannType)).join(",");
+export function generateMethodDescriptor(paramsType: Array<UnannType>, result: string) {
+  const paramsDescriptor = paramsType.map(generateFieldDescriptor).join(",");
   const resultDescriptor = generateFieldDescriptor(result);
 
   return '(' + paramsDescriptor + ')' + resultDescriptor;

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -27,16 +27,16 @@ export class Compiler {
   private attributes: Array<AttributeInfo>;
 
   constructor() {
-    this.symbolTable = new SymbolTable();
+    this.setup();
+  }
+
+  private setup() {
     this.constantPoolManager = new ConstantPoolManager();
     this.interfaces = [];
     this.fields = [];
     this.methods = [];
     this.attributes = [];
-    this.setup();
-  }
-
-  private setup() {
+    this.symbolTable = new SymbolTable();
     this.symbolTable.insert("out", SymbolType.CLASS, {
       parentClassName: "java/lang/System",
       typeDescriptor: generateFieldDescriptor("java/io/PrintStream")
@@ -48,6 +48,7 @@ export class Compiler {
   }
 
   compile(ast: AST) {
+    this.setup();
     const classFiles: Array<ClassFile> = [];
     ast.topLevelClassOrInterfaceDeclarations.forEach(x => classFiles.push(this.compileClass(x)));
     return classFiles[0];

--- a/src/compiler/constant-pool-manager.ts
+++ b/src/compiler/constant-pool-manager.ts
@@ -50,6 +50,18 @@ export class ConstantPoolManager {
     });
   }
 
+  indexFieldrefInfo(className: string, fieldName: string, descriptor: string) {
+    return this.writeIfAbsent(CONSTANT_TAG.Fieldref, {
+      class: {
+        name: { value: className, }
+      },
+      nameAndType: {
+        name: { value: fieldName },
+        descriptor: { value: descriptor },
+      }
+    });
+  }
+
   indexMethodrefInfo(className: string, methodName: string, descriptor: string) {
     return this.writeIfAbsent(CONSTANT_TAG.Methodref, {
       class: {

--- a/src/compiler/constant-pool-manager.ts
+++ b/src/compiler/constant-pool-manager.ts
@@ -3,6 +3,7 @@ import { ConstantInfo } from "../ClassFile/types/constants";
 import {
   ConstantClassValue,
   ConstantFieldrefValue,
+  ConstantIntegerValue,
   ConstantMethodrefValue,
   ConstantNameAndTypeValue,
   ConstantStringValue,
@@ -36,6 +37,12 @@ export class ConstantPoolManager {
     return this.writeIfAbsent(CONSTANT_TAG.Utf8, {
       value: value
     });
+  }
+
+  indexIntegerInfo(value: number) {
+    return this.writeIfAbsent(CONSTANT_TAG.Integer, {
+      value: value
+    })
   }
 
   indexClassInfo(className: string) {
@@ -125,6 +132,9 @@ export class ConstantPoolManager {
       case CONSTANT_TAG.Utf8:
         this.writeUtf8Info(task.value as ConstantUtf8Value);
         break;
+      case CONSTANT_TAG.Integer:
+        this.writeIntegerInfo(task.value as ConstantIntegerValue);
+        break;
       case CONSTANT_TAG.Class:
         this.writeClassInfo(task.value as ConstantClassValue);
         break;
@@ -152,6 +162,13 @@ export class ConstantPoolManager {
     });
   }
 
+  private writeIntegerInfo(val: ConstantIntegerValue) {
+    this.constantPool.push({
+      tag: CONSTANT_TAG.Integer,
+      value: val.value,
+    });
+  }
+
   private writeClassInfo(val: ConstantClassValue) {
     const nameIndex = this.addUtf8Info(val.name);
     this.constantPool.push({
@@ -165,16 +182,6 @@ export class ConstantPoolManager {
     this.constantPool.push({
       tag: CONSTANT_TAG.String,
       stringIndex: stringIndex,
-    });
-  }
-
-  private writeNameAndTypeInfo(val: ConstantNameAndTypeValue) {
-    const nameIndex = this.addUtf8Info(val.name);
-    const descriptorIndex = this.addUtf8Info(val.descriptor);
-    this.constantPool.push({
-      tag: CONSTANT_TAG.NameAndType,
-      nameIndex: nameIndex,
-      descriptorIndex: descriptorIndex,
     });
   }
 
@@ -196,5 +203,15 @@ export class ConstantPoolManager {
       classIndex: classIndex,
       nameAndTypeIndex: nameAndTypeIndex,
     })
+  }
+
+  private writeNameAndTypeInfo(val: ConstantNameAndTypeValue) {
+    const nameIndex = this.addUtf8Info(val.name);
+    const descriptorIndex = this.addUtf8Info(val.descriptor);
+    this.constantPool.push({
+      tag: CONSTANT_TAG.NameAndType,
+      nameIndex: nameIndex,
+      descriptorIndex: descriptorIndex,
+    });
   }
 }

--- a/src/compiler/constant-pool-manager.ts
+++ b/src/compiler/constant-pool-manager.ts
@@ -32,28 +32,54 @@ export class ConstantPoolManager {
     return this.constantPool;
   }
 
-  addUtf8Info(value: ConstantUtf8Value) {
+  indexUtf8Info(value: string) {
+    return this.writeIfAbsent(CONSTANT_TAG.Utf8, {
+      value: value
+    });
+  }
+
+  indexClassInfo(className: string) {
+    return this.writeIfAbsent(CONSTANT_TAG.Class, {
+      name: { value: className }
+    });
+  }
+
+  indexStringInfo(string: string) {
+    return this.writeIfAbsent(CONSTANT_TAG.String, {
+      string: { value: string }
+    });
+  }
+
+  indexMethodrefInfo(className: string, methodName: string, descriptor: string) {
+    return this.writeIfAbsent(CONSTANT_TAG.Methodref, {
+      class: {
+        name: { value: className, }
+      },
+      nameAndType: {
+        name: { value: methodName },
+        descriptor: { value: descriptor },
+      }
+    });
+  }
+
+  indexNameAndTypeInfo(name: string, type: string) {
+    return this.writeIfAbsent(CONSTANT_TAG.NameAndType, {
+      name: { value: name },
+      descriptor: { value: type }
+    });
+  }
+
+
+  private addUtf8Info(value: ConstantUtf8Value) {
     return this.writeIfAbsent(CONSTANT_TAG.Utf8, value);
   }
 
-  addClassInfo(value: ConstantClassValue) {
+  private addClassInfo(value: ConstantClassValue) {
     return this.writeIfAbsent(CONSTANT_TAG.Class, value);
   }
 
-  addStringInfo(value: ConstantStringValue) {
-    return this.writeIfAbsent(CONSTANT_TAG.String, value);
-  }
-
-  addNameAndTypeInfo(value: ConstantNameAndTypeValue) {
+  private addNameAndTypeInfo(value: ConstantNameAndTypeValue) {
     return this.writeIfAbsent(CONSTANT_TAG.NameAndType, value);
-  }
-
-  addFieldrefInfo(value: ConstantFieldrefValue) {
-    return this.writeIfAbsent(CONSTANT_TAG.Fieldref, value);
-  }
-
-  addMethodrefInfo(value: ConstantMethodrefValue) {
-    return this.writeIfAbsent(CONSTANT_TAG.Methodref, value);
   }
 
   private writeIfAbsent(tag: CONSTANT_TAG, value: ConstantTypeValue) {

--- a/src/compiler/constant-value-types.ts
+++ b/src/compiler/constant-value-types.ts
@@ -1,13 +1,25 @@
+export interface ConstantUtf8Value {
+  value: string;
+}
+
+export interface ConstantIntegerValue {
+  value: number;
+}
+
 export interface ConstantClassValue {
   name: ConstantUtf8Value;
 }
 
-export interface ConstantMethodrefValue {
+export interface ConstantStringValue {
+  string: ConstantUtf8Value
+}
+
+export interface ConstantFieldrefValue {
   class: ConstantClassValue;
   nameAndType: ConstantNameAndTypeValue;
 }
 
-export interface ConstantFieldrefValue {
+export interface ConstantMethodrefValue {
   class: ConstantClassValue;
   nameAndType: ConstantNameAndTypeValue;
 }
@@ -17,18 +29,12 @@ export interface ConstantNameAndTypeValue {
   descriptor: ConstantUtf8Value;
 }
 
-export interface ConstantStringValue {
-  string: ConstantUtf8Value
-}
-
-export interface ConstantUtf8Value {
-  value: string;
-}
-
 export type ConstantTypeValue =
+  | ConstantUtf8Value
+  | ConstantIntegerValue
   | ConstantClassValue
-  | ConstantMethodrefValue
-  | ConstantNameAndTypeValue
   | ConstantStringValue
-  | ConstantUtf8Value;
+  | ConstantFieldrefValue
+  | ConstantMethodrefValue
+  | ConstantNameAndTypeValue;
 

--- a/src/compiler/symbol-table.ts
+++ b/src/compiler/symbol-table.ts
@@ -1,0 +1,77 @@
+export type Symbol = {
+  name: string,
+  type: SymbolType
+};
+
+export enum SymbolType {
+  CLASS,
+  VARIABLE
+}
+
+export interface SymbolInfo {
+  index?: number,
+  parentClassName?: string,
+  typeDescriptor?: string
+};
+
+type Table = Map<string, SymbolInfo>;
+
+export class SymbolTable {
+  private tables: Array<Table>;
+  private curTable: Table;
+  private curIdx: number;
+
+  constructor() {
+    this.tables = [this.getNewTable()];
+    this.curTable = this.tables[0];
+    this.curIdx = 0;
+  }
+
+  private getNewTable() {
+    return new Map<string, SymbolInfo>();
+  }
+
+  extend() {
+    const table = this.getNewTable();
+    this.tables.push(table);
+    this.curTable = table;
+    this.curIdx++;
+  }
+
+  teardown() {
+    this.tables.pop();
+    this.curIdx--;
+    this.curTable = this.tables[this.curIdx];
+  }
+
+  insert(name: string, type: SymbolType, info: SymbolInfo) {
+    const symbol: Symbol = {
+      name: name,
+      type: type
+    };
+    const key = JSON.stringify(symbol);
+
+    if (this.curTable.has(key)) {
+      throw new Error("Same symbol already exists in the table");
+    }
+
+    this.curTable.set(key, info);
+  }
+
+  query(name: string, type: SymbolType): SymbolInfo {
+    const symbol: Symbol = {
+      name: name,
+      type: type
+    };
+    const key = JSON.stringify(symbol);
+
+    for (let i = this.curIdx; i >= 0; i--) {
+      const table = this.tables[i];
+      if (table.has(key)) {
+        return table.get(key) as SymbolInfo;
+      }
+    }
+
+    throw new Error("Symbol " + name + " with type " + type + " is undefined");
+  }
+}

--- a/src/compiler/utils.ts
+++ b/src/compiler/utils.ts
@@ -1,5 +1,0 @@
-import * as fs from "fs";
-
-export function writeToFile(filename: string, binary: Uint8Array) {
-  fs.writeFileSync(filename, binary);
-}


### PR DESCRIPTION
- Add compiler support for followings (unless otherwise stated, all applicable only to `int` type):
  - local variable declaration
  - arithmetic expression involving only binary operators
  - `println` method that takes `String` or `int` type argument
  - (nested) `if` `else` statements
  - `while` and `do while` loops
  - `for` loop with the form `for (init; cond; update) {}`
  - condition expression involved in `if`/`else if`/`while`/`for` can only have `int` or boolean literal, and can support all logical operators except logical not (`!`)
- Tests will be added in another PR to avoid huge PR and ease process of reviewing