### PR TITLE
Fix compiler test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'oracle'
-          java-version: '17.0'
+          java-version: '17'
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           test-script: yarn test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         run: yarn build
       - uses: actions/setup-java@v4
         with:
+          distribution: 'oracle'
           java-version: '17.0'
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
       - run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17.0'
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           test-script: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,5 @@ lerna-debug.log*
 .vscode/settings.json
 
 
-# generated class files, test output
+# generated class files
 *.class
-src/compiler/__tests__/output

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,7 @@ lerna-debug.log*
 .env.local
 .vscode/settings.json
 
+
+# generated class files, test output
 *.class
+src/compiler/__tests__/output

--- a/src/compiler/__tests__/test-utils.ts
+++ b/src/compiler/__tests__/test-utils.ts
@@ -35,8 +35,8 @@ export function runTest(program: string, expectedResult: string) {
 
   const prevDir = process.cwd();
   process.chdir(pathToTestDir);
-  execSync("java -noverify Main > output 2> err.log");
-  const actualResult = fs.readFileSync("./output", 'utf-8');
+  execSync("java -noverify Main > output.log 2> err.log");
+  const actualResult = fs.readFileSync("./output.log", 'utf-8');
   process.chdir(prevDir);
 
   expect(actualResult).toBe(expectedResult);

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -14,8 +14,8 @@ import { SymbolTable } from "./symbol-table";
 import { generateCode } from "./code-generator";
 
 const MAGIC = 0xcafebabe;
+const MAJOR_VERSION = 45;
 const MINOR_VERSION = 0;
-const MAJOR_VERSION = 61;
 
 export class Compiler {
   private symbolTable: SymbolTable;

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -14,8 +14,8 @@ import { SymbolTable } from "./symbol-table";
 import { generateCode } from "./code-generator";
 
 const MAGIC = 0xcafebabe;
-const MAJOR_VERSION = 45;
 const MINOR_VERSION = 0;
+const MAJOR_VERSION = 52;
 
 export class Compiler {
   private symbolTable: SymbolTable;


### PR DESCRIPTION
- Added java version into workflow
- The single test still failing CI would be fixed by #30 
- For running compiler's tests locally
  - use a java version that is between 11 and 17
  - tests might fail due the CRLF/LF differences in different platform, this would be fixed in another future PR