### PR TITLE
Use method descriptors after overloading

### DIFF
--- a/src/ast/types/blocks-and-statements.ts
+++ b/src/ast/types/blocks-and-statements.ts
@@ -1,3 +1,4 @@
+import { Closure } from "../../ec-evaluator/types";
 import { BaseNode } from "./ast";
 import { Identifier, UnannType } from "./classes";
 
@@ -288,4 +289,14 @@ export interface TernaryExpression extends BaseNode {
   condition: Expression;
   consequent: Expression;
   alternate: Expression;
+}
+
+export interface MethodDescriptor extends BaseNode {
+  kind: "Descriptor";
+  value: string;
+  returnType: string;
+  identifier: string;
+  formalParameterTypes: string[];
+  closure: Closure;
+  isStatic: boolean;
 }

--- a/src/ec-evaluator/index.ts
+++ b/src/ec-evaluator/index.ts
@@ -29,6 +29,7 @@ export const runECEvaluator = (
   } catch (e) {
     // Possible interpreting language error thrown, so conversion to RuntimeError may be required.
     const error = e.type ? e : new RuntimeError(e.message);
+    console.log(error);
     context.errors.push(error);
     return new Promise((resolve, _) => {
       resolve({ status: 'error', context } as Error);

--- a/src/ec-evaluator/types.ts
+++ b/src/ec-evaluator/types.ts
@@ -1,5 +1,5 @@
 import { Node } from "../ast/types/ast";
-import { Expression, Literal, Void } from "../ast/types/blocks-and-statements";
+import { Expression, Literal, Void, MethodDescriptor } from "../ast/types/blocks-and-statements";
 import {
   ConstructorDeclaration,
   FieldDeclaration,
@@ -121,7 +121,7 @@ export type Instr =
  * Components
  */
 export type ControlItem = Node | Instr;
-export type StashItem = Primitive | Reference | Value | Void | Type;
+export type StashItem = Primitive | Reference | Value | Void | Type | MethodDescriptor;
 
 export type Name = string;
 export type Value = Variable | Closure | Class;

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -7,6 +7,7 @@ import {
   Literal,
   MethodInvocation,
   ReturnStatement,
+  MethodDescriptor,
 } from "../ast/types/blocks-and-statements";
 import {
   ConstructorDeclaration,
@@ -453,11 +454,11 @@ export const resOverload = (
 
 export const resOverride = (
   classToSearchIn: Class,
-  overloadResolvedClosure: Closure,
+  overloadResolvedMethodDescriptor: MethodDescriptor,
 ): Closure => {
-  const overloadResolvedMtd = overloadResolvedClosure.mtdOrCon as MethodDeclaration;
-  const name = overloadResolvedMtd.methodHeader.identifier;
-  const overloadResolvedClosureParams = overloadResolvedMtd.methodHeader.formalParameterList;
+  // const overloadResolvedMtd = overloadResolvedClosure.mtdOrCon as MethodDeclaration;
+  const name = overloadResolvedMethodDescriptor.identifier;
+  const overloadResolvedClosureParams = overloadResolvedMethodDescriptor.formalParameterTypes;
 
   const closures: Closure[] = [];
   for (const [closureName, closure] of classToSearchIn.frame.frame.entries()) {
@@ -467,7 +468,7 @@ export const resOverride = (
     }
   }
 
-  let overrideResolvedClosure = overloadResolvedClosure;
+  let overrideResolvedClosure = overloadResolvedMethodDescriptor.closure;
   for (const closure of closures) {
     const params = (closure.mtdOrCon as MethodDeclaration).methodHeader.formalParameterList;
       
@@ -475,7 +476,7 @@ export const resOverride = (
     
     let match = true;
     for (let i = 0; i < overloadResolvedClosureParams.length; i++) {
-      match &&= (params[i].unannType === overloadResolvedClosureParams[i].unannType);
+      match &&= (params[i].unannType === overloadResolvedClosureParams[i]);
       if (!match) break; // short circuit
     }
     


### PR DESCRIPTION
This PR targets an improvement to the CSEC machine. It replaces closures with human-readable method descriptors after method overloading to better reflect Java's native behaviour.

The current method descriptor format used for each kind of method is:
- Instance methods (non-constructors): `<return type> <identifier>(<parameter types>)`
- Static methods: `<return type> <class>::<identifier>(<parameter types>)`
- Constructors: `<class>(<parameter types>)`

This implements another type of stash item `MethodDescriptor` that holds information necessary for overriding, including the return type, identifier, parameter types, and also a human-readable method descriptor that can be displayed.

- [x] Method descriptors for instance and class methods
- [ ] Method descriptors for constructors
- [ ] Remove closure storage in `MethodDescriptor`: need to modify `resOverride` to pull the relevant items directly from the `MethodDescriptor`.